### PR TITLE
Add backend server setup

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "travonex-backend",
+  "version": "1.0.0",
+  "description": "Backend for Travonex project",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^7.5.0",
+    "firebase-admin": "^11.10.1",
+    "razorpay": "^2.8.5",
+    "cloudinary": "^1.34.0",
+    "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1",
+    "jest": "^29.6.4"
+  }
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const admin = require('firebase-admin');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+
+// MongoDB connection
+mongoose.connect(process.env.MONGODB_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+}).then(() => {
+  console.log('Connected to MongoDB');
+}).catch((err) => {
+  console.error('MongoDB connection error:', err);
+});
+
+// Firebase Admin initialization
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert({
+      projectId: process.env.FIREBASE_PROJECT_ID,
+      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+      privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
+    }),
+  });
+}
+
+app.use(express.json());
+
+app.get('/health-check', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+const port = process.env.PORT || 4000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- implement Express server in `backend/src/server.js`
- connect to MongoDB
- initialize Firebase Admin
- expose `/health-check` endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f98208908328b96bd4c34a5108b9