### PR TITLE
Implement user bookings endpoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "ts-node src/index.ts",
     "test": "jest"
-    "dev": "ts-node src/index.ts"
   },
   "dependencies": {
     "body-parser": "^1.20.2",
@@ -17,8 +16,6 @@
     "mongoose": "^7.6.0",
     "razorpay": "^2.9.6",
     "jsonwebtoken": "^9.0.2"
-
-    "razorpay": "^2.9.6"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.6",
@@ -33,7 +30,5 @@
     "supertest": "^6.3.4",
     "@types/supertest": "^2.0.12",
     "mongodb-memory-server": "^8.12.2"
-
-    "typescript": "^5.3.3"
   }
 }

--- a/backend/src/middleware/verifyJwt.ts
+++ b/backend/src/middleware/verifyJwt.ts
@@ -7,9 +7,6 @@ export interface AuthUser {
 }
 
 export function verifyJwt(requiredRole?: string | string[]) {
-
-export function verifyJwt(requiredRole?: string) {
-
   return (req: Request, res: Response, next: NextFunction): void => {
     const header = req.headers.authorization;
     if (!header || !header.startsWith('Bearer ')) {
@@ -21,20 +18,18 @@ export function verifyJwt(requiredRole?: string) {
       const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as AuthUser;
       (req as any).authUser = payload;
       if (requiredRole) {
-        let allowed: string[] = Array.isArray(requiredRole) ? requiredRole : [requiredRole];
+        let allowed = Array.isArray(requiredRole) ? requiredRole : [requiredRole];
         if (allowed.includes('ADMIN')) {
-          allowed = allowed.flatMap(r => r === 'ADMIN' ? ['Super Admin', 'Finance Manager', 'Support Agent', 'Operations Manager'] : [r]);
+          allowed = allowed.flatMap(r =>
+            r === 'ADMIN'
+              ? ['Super Admin', 'Finance Manager', 'Support Agent', 'Operations Manager']
+              : [r]
+          );
         }
         if (!allowed.includes(payload.role)) {
           res.status(403).json({ message: 'Forbidden' });
           return;
         }
-
-
-      if (requiredRole && payload.role !== requiredRole) {
-        res.status(403).json({ message: 'Forbidden' });
-        return;
-
       }
       next();
     } catch {

--- a/backend/src/models/trip.ts
+++ b/backend/src/models/trip.ts
@@ -21,13 +21,6 @@ export interface ITrip extends Document {
   organizerId: string;
   cancellationRules?: { days: number; refundPercentage: number }[];
   status: 'Published' | 'Draft' | 'Unlisted' | 'Pending Approval' | 'Rejected';
-
-
-  status: 'Published' | 'Draft' | 'Unlisted' | 'Pending Approval' | 'Rejected';
-
-
-status: 'Published' | 'Draft' | 'Unlisted' | 'Pending Approval' | 'Rejected';
-
 }
 
 const batchSchema = new Schema<ITripBatch>({

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response, NextFunction } from 'express';
 import User from '../models/user';
+import Booking from '../models/booking';
 import { verifyJwt } from '../middleware/verifyJwt';
 
 const router = express.Router();
@@ -10,6 +11,13 @@ router.get('/me', (req: Request, res: Response, next: NextFunction) => {
     const user = await User.findById((req as any).authUser.id);
     if (!user) return res.status(404).json({ message: 'User not found' });
     res.json(user);
+  })().catch(next);
+});
+
+router.get('/me/bookings', (req: Request, res: Response, next: NextFunction) => {
+  (async () => {
+    const bookings = await Booking.find({ userId: (req as any).authUser.id });
+    res.json(bookings);
   })().catch(next);
 });
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -12,12 +12,6 @@
   },
   "ts-node": {
     "transpileOnly": true
-
-    "types": ["node"]
   },
-  "ts-node": {
-    "transpileOnly": true
-    "forceConsistentCasingInFileNames": true
-  },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/src/app/api/users/me/bookings/route.ts
+++ b/src/app/api/users/me/bookings/route.ts
@@ -1,12 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
 
-export async function GET() {
-  const cookie = cookies().get('authToken');
+export async function GET(request: Request) {
   const res = await fetch(`${BACKEND_URL}/api/users/me/bookings`, {
-    headers: { Authorization: cookie ? `Bearer ${cookie.value}` : '' },
+    headers: { Authorization: request.headers.get('Authorization') || '' },
   });
   const data = await res.json();
   return NextResponse.json(data, { status: res.status });


### PR DESCRIPTION
## Summary
- fix corrupted backend configs
- add `/api/users/me/bookings` route
- expose new endpoint through frontend proxy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d44a0fea08328af5ae3b909ad4b4e