### PR TITLE
Add coupons validation API

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import Razorpay from 'razorpay';
 import authRoutes from './routes/auth';
 import tripRoutes from './routes/trips';
 import bookingRoutes from './routes/bookings';
+import couponRoutes from './routes/coupons';
 import organizerRoutes from './routes/organizers';
 import organizerProfileRoutes from './routes/organizerProfile';
 import adminRoutes from './routes/admin';
@@ -40,6 +41,7 @@ app.use('/api/organizers', organizerProfileRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/content', contentRoutes);
+app.use('/api/coupons', couponRoutes);
 
 
 if (!admin.apps.length) {

--- a/backend/src/routes/coupons.ts
+++ b/backend/src/routes/coupons.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import Coupon from '../models/coupon';
+
+const router = express.Router();
+
+router.post('/validate', async (req, res, next) => {
+  try {
+    const { code } = req.body;
+    if (!code) {
+      return res.status(400).json({ message: 'Coupon code required' });
+    }
+    const coupon = await Coupon.findOne({ code, isActive: true });
+    if (!coupon) {
+      return res.status(400).json({ message: 'Invalid coupon' });
+    }
+    res.json({
+      code: coupon.code,
+      discountType: coupon.discountType,
+      discountValue: coupon.discountValue,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/tests/routes/coupons.test.ts
+++ b/backend/tests/routes/coupons.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import express from 'express';
+
+import router from '../../src/routes/coupons';
+import Coupon from '../../src/models/coupon';
+
+jest.mock('../../src/models/coupon');
+
+const app = express();
+app.use(express.json());
+app.use(router);
+
+describe('coupons routes', () => {
+  it('returns discount info for valid coupon', async () => {
+    (Coupon.findOne as jest.Mock).mockResolvedValue({
+      code: 'SAVE10',
+      discountType: 'percent',
+      discountValue: 10,
+    });
+
+    const res = await request(app).post('/validate').send({ code: 'SAVE10' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      code: 'SAVE10',
+      discountType: 'percent',
+      discountValue: 10,
+    });
+  });
+
+  it('returns 400 for invalid coupon', async () => {
+    (Coupon.findOne as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app).post('/validate').send({ code: 'BAD' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('requires coupon code', async () => {
+    const res = await request(app).post('/validate').send({});
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add `coupons` router with `POST /validate`
- register the router in the express app
- test coupon validation flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e0aa62b548328af1e5d6e5e73674f