### PR TITLE
Add admin settings controller

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import bookingRoutes from './routes/bookings';
 import organizerRoutes from './routes/organizers';
 import organizerProfileRoutes from './routes/organizerProfile';
 import adminRoutes from './routes/admin';
+import adminSettingsRoutes from './routes/adminSettings';
 import userRoutes from './routes/users';
 import contentRoutes from './routes/content';
 import { errorHandler } from './middleware/errorHandler';
@@ -38,6 +39,7 @@ app.use('/api/bookings', bookingRoutes);
 app.use('/api/organizers/me', organizerRoutes);
 app.use('/api/organizers', organizerProfileRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/admin/settings', adminSettingsRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/content', contentRoutes);
 

--- a/backend/src/models/adminSetting.ts
+++ b/backend/src/models/adminSetting.ts
@@ -1,0 +1,13 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IAdminSetting extends Document {
+  section: string;
+  settings: Record<string, any>;
+}
+
+const adminSettingSchema = new Schema<IAdminSetting>({
+  section: { type: String, required: true, unique: true },
+  settings: { type: Schema.Types.Mixed, default: {} },
+});
+
+export default mongoose.model<IAdminSetting>('AdminSetting', adminSettingSchema);

--- a/backend/src/routes/adminSettings.ts
+++ b/backend/src/routes/adminSettings.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import AdminSetting from '../models/adminSetting';
+import { verifyJwt } from '../middleware/verifyJwt';
+
+const router = express.Router();
+router.use(verifyJwt('ADMIN'));
+
+router.put('/:section', async (req, res, next) => {
+  try {
+    const { section } = req.params;
+    const settings = req.body;
+    const doc = await AdminSetting.findOneAndUpdate(
+      { section },
+      { section, settings },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+    res.json(doc);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/:section', async (req, res, next) => {
+  try {
+    const doc = await AdminSetting.findOne({ section: req.params.section });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/tests/routes/adminSettings.test.ts
+++ b/backend/tests/routes/adminSettings.test.ts
@@ -1,0 +1,36 @@
+import request from 'supertest';
+import express from 'express';
+
+jest.mock('../../src/middleware/verifyJwt', () => ({
+  verifyJwt: () => (_req: any, _res: any, next: any) => next()
+}));
+
+import router from '../../src/routes/adminSettings';
+import AdminSetting from '../../src/models/adminSetting';
+
+jest.mock('../../src/models/adminSetting');
+
+const app = express();
+app.use(express.json());
+app.use(router);
+
+describe('adminSettings routes', () => {
+  it('upserts settings for section', async () => {
+    (AdminSetting.findOneAndUpdate as jest.Mock).mockResolvedValue({
+      section: 'general',
+      settings: { enabled: true }
+    });
+
+    const res = await request(app)
+      .put('/general')
+      .send({ enabled: true });
+
+    expect(AdminSetting.findOneAndUpdate).toHaveBeenCalledWith(
+      { section: 'general' },
+      { section: 'general', settings: { enabled: true } },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.section).toBe('general');
+  });
+});


### PR DESCRIPTION
## Summary
- add `AdminSetting` model for persisting admin settings
- create `adminSettings` routes to manage admin settings
- expose the new router from the main server
- test the new endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e0aa9911c832895ecbcc220b5c86e