### PR TITLE
Align trip and organizer schemas with types

### DIFF
--- a/backend/migrations/20240608_addTripFields.ts
+++ b/backend/migrations/20240608_addTripFields.ts
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import Trip from '../src/models/trip';
+
+dotenv.config();
+
+async function run() {
+  await mongoose.connect(process.env.MONGODB_URI || '');
+
+  await Trip.updateMany({}, {
+    $set: {
+      itinerary: [],
+      difficulty: '',
+      isFeatured: false,
+      isFeaturedRequest: false
+    }
+  });
+
+  console.log('Migration completed');
+  await mongoose.disconnect();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/models/organizer.ts
+++ b/backend/src/models/organizer.ts
@@ -16,6 +16,7 @@ export interface IOrganizer extends Document {
   joinDate: Date;
   kycStatus: 'Incomplete' | 'Pending' | 'Verified' | 'Rejected' | 'Suspended';
   organizerType?: string;
+  logo?: string;
   address?: string;
   website?: string;
   experience?: number;
@@ -23,6 +24,10 @@ export interface IOrganizer extends Document {
   authorizedSignatoryName?: string;
   authorizedSignatoryId?: string;
   emergencyContact?: string;
+  pan?: string;
+  gstin?: string;
+  bankAccountNumber?: string;
+  ifscCode?: string;
   documents: IOrganizerDocument[];
   vendorAgreementStatus: 'Not Submitted' | 'Submitted' | 'Verified' | 'Rejected';
   isProfileComplete: boolean;
@@ -39,6 +44,7 @@ const organizerSchema = new Schema<IOrganizer>({
     default: 'Incomplete',
   },
   organizerType: String,
+  logo: String,
   address: String,
   website: String,
   experience: Number,
@@ -46,6 +52,10 @@ const organizerSchema = new Schema<IOrganizer>({
   authorizedSignatoryName: String,
   authorizedSignatoryId: String,
   emergencyContact: String,
+  pan: String,
+  gstin: String,
+  bankAccountNumber: String,
+  ifscCode: String,
   documents: {
     type: [
       new Schema<IOrganizerDocument>({

--- a/backend/src/models/trip.ts
+++ b/backend/src/models/trip.ts
@@ -9,18 +9,71 @@ export interface ITripBatch {
   availableSlots: number;
 }
 
+export interface IPoint {
+  label: string;
+  time: string;
+  mapsLink: string;
+}
+
+export interface IItineraryItem {
+  day: number;
+  title: string;
+  description: string;
+  image?: string;
+  imageHint?: string;
+}
+
+export interface IFAQ {
+  question: string;
+  answer: string;
+}
+
 export interface ITrip extends Document {
   slug: string;
   title: string;
   location: string;
   city: string;
   tripType: string;
+  difficulty?: string;
+  duration?: string;
+  description?: string;
+  minAge?: number;
+  maxAge?: number;
+  pickupCity?: string;
+  pickupPoints?: IPoint[];
+  dropoffPoints?: IPoint[];
+  interests?: string[];
+  category?: string;
+  isFeaturedRequest?: boolean;
+
+  // Pricing
   price: number;
+  taxIncluded?: boolean;
+  taxPercentage?: number;
+
+  // Visuals
   image: string;
+  imageHint?: string;
+  gallery?: { url: string; hint: string }[];
+
+  // Details
+  inclusions?: string[];
+  exclusions?: string[];
+  itinerary?: IItineraryItem[];
+
+  // Batches & Policies
   batches: ITripBatch[];
-  organizerId: string;
+  cancellationPolicy?: string;
   cancellationRules?: { days: number; refundPercentage: number }[];
+  faqs?: IFAQ[];
+
+  // Metadata & Status
+  reviews?: { id: string; userId: string; rating: number; comment: string }[];
+  organizerId: string;
+  isFeatured?: boolean;
+  isBannerTrip?: boolean;
   status: 'Published' | 'Draft' | 'Unlisted' | 'Pending Approval' | 'Rejected';
+  adminNotes?: string;
 }
 
 const batchSchema = new Schema<ITripBatch>({
@@ -32,22 +85,79 @@ const batchSchema = new Schema<ITripBatch>({
   availableSlots: Number,
 });
 
+const pointSchema = new Schema<IPoint>({
+  label: String,
+  time: String,
+  mapsLink: String,
+}, { _id: false });
+
+const itineraryItemSchema = new Schema<IItineraryItem>({
+  day: Number,
+  title: String,
+  description: String,
+  image: String,
+  imageHint: String,
+}, { _id: false });
+
+const faqSchema = new Schema<IFAQ>({
+  question: String,
+  answer: String,
+}, { _id: false });
+
+const gallerySchema = new Schema({ url: String, hint: String }, { _id: false });
+
+const reviewSchema = new Schema({
+  id: String,
+  userId: String,
+  rating: Number,
+  comment: String,
+}, { _id: false });
+
 const tripSchema = new Schema<ITrip>({
   slug: { type: String, required: true, unique: true },
   title: { type: String, required: true },
   location: String,
   city: String,
   tripType: String,
+  difficulty: String,
+  duration: String,
+  description: String,
+  minAge: Number,
+  maxAge: Number,
+  pickupCity: String,
+  pickupPoints: [pointSchema],
+  dropoffPoints: [pointSchema],
+  interests: [String],
+  category: String,
+  isFeaturedRequest: { type: Boolean, default: false },
+
   price: Number,
+  taxIncluded: Boolean,
+  taxPercentage: Number,
+
   image: String,
+  imageHint: String,
+  gallery: [gallerySchema],
+
+  inclusions: [String],
+  exclusions: [String],
+  itinerary: [itineraryItemSchema],
+
   batches: [batchSchema],
-  organizerId: String,
+  cancellationPolicy: String,
   cancellationRules: [{ days: Number, refundPercentage: Number }],
+  faqs: [faqSchema],
+
+  reviews: [reviewSchema],
+  organizerId: String,
+  isFeatured: { type: Boolean, default: false },
+  isBannerTrip: { type: Boolean, default: false },
   status: {
     type: String,
     enum: ['Published', 'Draft', 'Unlisted', 'Pending Approval', 'Rejected'],
     default: 'Draft',
   },
+  adminNotes: String,
 });
 
 export default mongoose.model<ITrip>('Trip', tripSchema);

--- a/backend/tests/models/organizer.test.ts
+++ b/backend/tests/models/organizer.test.ts
@@ -1,0 +1,5 @@
+import Organizer from '../../src/models/organizer';
+
+test('organizer schema has pan field', () => {
+  expect(Organizer.schema.path('pan')).toBeDefined();
+});

--- a/backend/tests/models/trip.test.ts
+++ b/backend/tests/models/trip.test.ts
@@ -3,3 +3,9 @@ import Trip from '../../src/models/trip';
 test('trip schema has slug', () => {
   expect(Trip.schema.path('slug')).toBeDefined();
 });
+
+test('trip schema has itinerary and featured flags', () => {
+  expect(Trip.schema.path('itinerary')).toBeDefined();
+  expect(Trip.schema.path('difficulty')).toBeDefined();
+  expect(Trip.schema.path('isFeatured')).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- expand `Trip` model with itinerary, difficulty, featured flags and more fields
- extend `Organizer` schema for financial and profile data
- add migration script for legacy trips
- cover new schema fields in tests

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_686e0aae544c83289419b947c49b1a56