### PR TITLE
Add Firebase client setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,11 @@
 GOOGLE_API_KEY=YOUR_GOOGLE_API_KEY
 NEXT_PUBLIC_BACKEND_URL=http://localhost:5000
+
+# Firebase configuration for the frontend
+NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
+NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your-measurement-id

--- a/README2.md
+++ b/README2.md
@@ -63,6 +63,15 @@ The application uses environment variables for configuration, both for the AI fe
 
     # Base URL of the Node.js/Express backend
     NEXT_PUBLIC_BACKEND_URL=http://localhost:5000
+
+    # Firebase configuration for the frontend
+    NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+    NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
+    NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
+    NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your-measurement-id
     ```
 
 3.  **Important**: Replace `YOUR_GOOGLE_API_KEY_HERE` with your actual API key from Google AI Studio. Update `NEXT_PUBLIC_BACKEND_URL` if your backend runs on a different host or port.
@@ -185,7 +194,7 @@ A: Currently, all data is mocked and lives in `src/lib/mock-data.ts`. The next s
 
 ## 8. Backend Integration & Testing
 
-The repository includes a minimal Express backend in the `backend/` directory. Copy `backend/.env.example` to `backend/.env` and update the connection details for MongoDB, Firebase and Razorpay.
+The repository includes a minimal Express backend in the `backend/` directory. Copy `backend/.env.example` to `backend/.env` and update the connection details for MongoDB, Firebase and Razorpay. The `.env.example` file now also includes the Firebase frontend keys so you can run the Next.js app locally with Firebase authentication.
 
 To run the backend in development mode:
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,12 @@ FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR-KEY\n-----END PRIVATE KE
 RAZORPAY_KEY_ID=rzp_test_key
 RAZORPAY_KEY_SECRET=rzp_test_secret
 JWT_SECRET=your_jwt_secret
+
+# Firebase configuration for frontend
+NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
+NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your-measurement-id

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,15 @@
+import { initializeApp, getApps, getApp } from 'firebase/app';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+};
+
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+
+export default app;


### PR DESCRIPTION
## Summary
- add Firebase environment variables for frontend usage
- initialize client app in `src/lib/firebase.ts`
- document Firebase setup in README2

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e1d550eac832891fc73d1201b94c6