### PR TITLE
Add firebaseUid field to user and organizer models

### DIFF
--- a/backend/migrations/20240609_addFirebaseUid.ts
+++ b/backend/migrations/20240609_addFirebaseUid.ts
@@ -1,0 +1,30 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import User from '../src/models/user';
+import Organizer from '../src/models/organizer';
+
+dotenv.config();
+
+async function run() {
+  await mongoose.connect(process.env.MONGODB_URI || '');
+
+  const users = await User.find({ firebaseUid: { $exists: false } });
+  for (const u of users) {
+    u.firebaseUid = u.id.toString();
+    await u.save();
+  }
+
+  const organizers = await Organizer.find({ firebaseUid: { $exists: false } });
+  for (const o of organizers) {
+    o.firebaseUid = o.id.toString();
+    await o.save();
+  }
+
+  console.log('Migration completed');
+  await mongoose.disconnect();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/models/organizer.ts
+++ b/backend/src/models/organizer.ts
@@ -13,6 +13,7 @@ export interface IOrganizer extends Document {
   name: string;
   email: string;
   phone: string;
+  firebaseUid: string;
   joinDate: Date;
   kycStatus: 'Incomplete' | 'Pending' | 'Verified' | 'Rejected' | 'Suspended';
   organizerType?: string;
@@ -37,6 +38,7 @@ const organizerSchema = new Schema<IOrganizer>({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
   phone: { type: String, required: true, unique: true },
+  firebaseUid: { type: String, required: true, unique: true },
   joinDate: { type: Date, default: Date.now },
   kycStatus: {
     type: String,

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -12,6 +12,7 @@ export interface IUser extends Document {
   name: string;
   email: string;
   phone: string;
+  firebaseUid: string;
   joinDate: Date;
   status: 'Active' | 'Suspended';
   avatar: string;
@@ -25,6 +26,7 @@ const userSchema = new Schema<IUser>({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
   phone: { type: String, required: true, unique: true },
+  firebaseUid: { type: String, required: true, unique: true },
   joinDate: { type: Date, default: Date.now },
   status: { type: String, enum: ['Active', 'Suspended'], default: 'Active' },
   avatar: { type: String, default: '' },

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -202,9 +202,7 @@ router.patch('/organizers/:id/documents/:docId', (req, res, next) => {
   (async () => {
     const organizer = await Organizer.findById(req.params.id);
     if (!organizer) return res.status(404).json({ message: 'Organizer not found' });
-    const doc = (organizer as any).documents.id(req.params.docId);
-
-    const doc = (organizer.documents as any).id(req.params.docId);
+  const doc = (organizer.documents as any).id(req.params.docId);
     if (!doc) return res.status(404).json({ message: 'Document not found' });
     doc.status = req.body.status;
     doc.rejectionReason = req.body.rejectionReason;
@@ -327,7 +325,9 @@ router.get('/audit-logs', (_req, res, next) => {
   AuditLog.find()
     .sort({ timestamp: -1 })
     .then(logs => res.json(logs))
-=======
+    .catch(next);
+});
+
 // ----- Categories -----
 router.get('/categories', (_req, res, next) => {
   Category.find()

--- a/backend/tests/models/organizer.test.ts
+++ b/backend/tests/models/organizer.test.ts
@@ -3,3 +3,7 @@ import Organizer from '../../src/models/organizer';
 test('organizer schema has pan field', () => {
   expect(Organizer.schema.path('pan')).toBeDefined();
 });
+
+test('organizer schema has firebaseUid field', () => {
+  expect(Organizer.schema.path('firebaseUid')).toBeDefined();
+});

--- a/backend/tests/models/user.test.ts
+++ b/backend/tests/models/user.test.ts
@@ -1,0 +1,5 @@
+import User from '../../src/models/user';
+
+test('user schema has firebaseUid field', () => {
+  expect(User.schema.path('firebaseUid')).toBeDefined();
+});

--- a/backend/tests/routes/admin-new.test.ts
+++ b/backend/tests/routes/admin-new.test.ts
@@ -8,7 +8,8 @@ jest.mock('../../src/middleware/verifyJwt', () => ({
   }
 }));
 
-import router from '../../src/routes/admin';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const router = require('../../src/routes/admin').default;
 import Category from '../../src/models/category';
 import Interest from '../../src/models/interest';
 import City from '../../src/models/city';

--- a/backend/tests/routes/admin.refunds.test.ts
+++ b/backend/tests/routes/admin.refunds.test.ts
@@ -8,7 +8,8 @@ jest.mock('../../src/middleware/verifyJwt', () => ({
   }
 }));
 
-import router from '../../src/routes/admin';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const router = require('../../src/routes/admin').default;
 import Booking from '../../src/models/booking';
 
 jest.mock('../../src/models/booking');

--- a/backend/tests/routes/admin.test.ts
+++ b/backend/tests/routes/admin.test.ts
@@ -4,12 +4,12 @@ import express from 'express';
 jest.mock('../../src/middleware/verifyJwt', () => ({
   verifyJwt: () => (req: any, _res: any, next: any) => {
     req.authUser = { id: 'admin1', role: 'ADMIN' };
-    req.authUser = { id: 'a1', role: 'Super Admin' };
     next();
   }
 }));
 
-import router from '../../src/routes/admin';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const router = require('../../src/routes/admin').default;
 import User from '../../src/models/user';
 import Organizer from '../../src/models/organizer';
 import AuditLog from '../../src/models/auditLog';
@@ -67,14 +67,17 @@ describe('admin audit logging', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual([{ id: 'log1' }]);
     expect(sortMock).toHaveBeenCalledWith({ timestamp: -1 });
+  });
+});
+
 describe('admin routes - me profile', () => {
   it('updates authenticated admin user', async () => {
-    (AdminUser.findByIdAndUpdate as jest.Mock).mockResolvedValue({ id: 'a1', name: 'New' });
+    (AdminUser.findByIdAndUpdate as jest.Mock).mockResolvedValue({ id: 'admin1', name: 'New' });
 
     const res = await request(app).put('/me/profile').send({ name: 'New' });
 
     expect(res.status).toBe(200);
-    expect(AdminUser.findByIdAndUpdate).toHaveBeenCalledWith('a1', { name: 'New' }, { new: true });
+    expect(AdminUser.findByIdAndUpdate).toHaveBeenCalledWith('admin1', { name: 'New' }, { new: true });
   });
 
   it('returns 404 when admin not found', async () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,6 +157,7 @@ export interface Organizer {
   id: string;
   name: string; // Business / Brand Name
   email: string; // Primary contact email for platform communication
+  firebaseUid: string;
   joinDate: string;
 
   // --- Profile Information ---
@@ -209,6 +210,7 @@ export interface User {
   name: string;
   email: string;
   phone: string;
+  firebaseUid: string;
   joinDate: string;
   status: 'Active' | 'Suspended';
   isProfileComplete: boolean; // Backend should set this to true only after all required fields are filled.


### PR DESCRIPTION
## Summary
- include `firebaseUid` in user and organizer schemas and interfaces
- update shared types
- add migration to backfill `firebaseUid`
- ensure admin route compiles and tests use CommonJS imports
- extend model tests to check for new field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e1d56b8008328ae547a6e8da021d9