### PR TITLE
Handle Firebase idToken login

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -202,8 +202,6 @@ router.patch('/organizers/:id/documents/:docId', (req, res, next) => {
   (async () => {
     const organizer = await Organizer.findById(req.params.id);
     if (!organizer) return res.status(404).json({ message: 'Organizer not found' });
-    const doc = (organizer as any).documents.id(req.params.docId);
-
     const doc = (organizer.documents as any).id(req.params.docId);
     if (!doc) return res.status(404).json({ message: 'Document not found' });
     doc.status = req.body.status;
@@ -327,7 +325,9 @@ router.get('/audit-logs', (_req, res, next) => {
   AuditLog.find()
     .sort({ timestamp: -1 })
     .then(logs => res.json(logs))
-=======
+    .catch(next);
+});
+
 // ----- Categories -----
 router.get('/categories', (_req, res, next) => {
   Category.find()

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,9 +1,10 @@
 import express from 'express';
 import jwt from 'jsonwebtoken';
+import admin from 'firebase-admin';
 import User from '../models/user';
 import Organizer from '../models/organizer';
 import AdminUser from '../models/adminUser';
-import { sendOtp, resendOtp, validateOtp } from '../services/otp';
+import { sendOtp, resendOtp } from '../services/otp';
 
 const router = express.Router();
 
@@ -56,37 +57,45 @@ router.post('/signup', async (req, res, next) => {
 // Login endpoint
 router.post('/login', async (req, res, next) => {
   try {
-    const { identifier, credential } = req.body;
-    if (!identifier || !credential) {
-      return res.status(400).json({ message: 'Identifier and credential required' });
+    const { identifier, credential, idToken } = req.body;
+
+    // Admin login continues to use identifier + credential
+    if (identifier && credential) {
+      const adminUser = await AdminUser.findOne({ email: identifier });
+      if (!adminUser) return res.status(404).json({ message: 'Account not found' });
+      if (credential !== 'password') {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const token = jwt.sign({ id: adminUser.id, role: 'ADMIN' }, process.env.JWT_SECRET || 'secret', { expiresIn: '7d' });
+      return res.json({ token, user: { id: adminUser.id, name: adminUser.name, email: adminUser.email, role: 'ADMIN' } });
     }
 
-    let user: any = await User.findOne({ $or: [{ email: identifier }, { phone: identifier }] });
+    if (!idToken) {
+      return res.status(400).json({ message: 'idToken required' });
+    }
+
+    let decoded;
+    try {
+      decoded = await admin.auth().verifyIdToken(idToken);
+    } catch {
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+
+    const orConditions: any[] = [{ firebaseUid: decoded.uid }];
+    if (decoded.email) orConditions.push({ email: decoded.email });
+    if (decoded.phone_number) orConditions.push({ phone: decoded.phone_number });
+
+    let user: any = await User.findOne({ $or: orConditions });
     let role = 'USER';
     if (!user) {
-      const organizer = await Organizer.findOne({ $or: [{ email: identifier }, { phone: identifier }] });
+      const organizer = await Organizer.findOne({ $or: orConditions });
       if (organizer) {
         user = organizer;
         role = 'ORGANIZER';
       }
     }
-    if (!user) {
-      const adminUser = await AdminUser.findOne({ email: identifier });
-      if (adminUser) {
-        user = adminUser;
-        role = 'ADMIN';
-      }
-    }
-    if (!user) return res.status(404).json({ message: 'Account not found' });
 
-    if (role === 'ADMIN') {
-      if (credential !== 'password') {
-        return res.status(401).json({ message: 'Invalid credentials' });
-      }
-    } else {
-      const valid = await validateOtp(identifier, credential);
-      if (!valid) return res.status(401).json({ message: 'Invalid OTP' });
-    }
+    if (!user) return res.status(404).json({ message: 'Account not found' });
 
     const token = jwt.sign({ id: user.id, role }, process.env.JWT_SECRET || 'secret', { expiresIn: '7d' });
     res.json({ token, user: { id: user.id, name: user.name, email: user.email, role } });

--- a/backend/tests/routes/admin.test.ts
+++ b/backend/tests/routes/admin.test.ts
@@ -3,8 +3,7 @@ import express from 'express';
 
 jest.mock('../../src/middleware/verifyJwt', () => ({
   verifyJwt: () => (req: any, _res: any, next: any) => {
-    req.authUser = { id: 'admin1', role: 'ADMIN' };
-    req.authUser = { id: 'a1', role: 'Super Admin' };
+    req.authUser = { id: 'admin1', role: 'Super Admin' };
     next();
   }
 }));
@@ -67,6 +66,9 @@ describe('admin audit logging', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual([{ id: 'log1' }]);
     expect(sortMock).toHaveBeenCalledWith({ timestamp: -1 });
+  });
+});
+
 describe('admin routes - me profile', () => {
   it('updates authenticated admin user', async () => {
     (AdminUser.findByIdAndUpdate as jest.Mock).mockResolvedValue({ id: 'a1', name: 'New' });
@@ -74,7 +76,7 @@ describe('admin routes - me profile', () => {
     const res = await request(app).put('/me/profile').send({ name: 'New' });
 
     expect(res.status).toBe(200);
-    expect(AdminUser.findByIdAndUpdate).toHaveBeenCalledWith('a1', { name: 'New' }, { new: true });
+    expect(AdminUser.findByIdAndUpdate).toHaveBeenCalledWith('admin1', { name: 'New' }, { new: true });
   });
 
   it('returns 404 when admin not found', async () => {

--- a/backend/tests/routes/auth.test.ts
+++ b/backend/tests/routes/auth.test.ts
@@ -1,6 +1,12 @@
 import request from 'supertest';
 import express from 'express';
 
+const verifyMock = jest.fn();
+jest.mock('firebase-admin', () => ({
+  auth: () => ({ verifyIdToken: verifyMock }),
+  default: { auth: () => ({ verifyIdToken: verifyMock }) }
+}));
+
 jest.mock('../../src/models/user');
 jest.mock('../../src/models/organizer');
 jest.mock('../../src/models/adminUser');
@@ -14,7 +20,7 @@ const app = express();
 app.use(express.json());
 app.use(router);
 
-describe('auth routes - otp flow', () => {
+describe('auth routes - firebase login', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -33,23 +39,22 @@ describe('auth routes - otp flow', () => {
     expect(first).not.toBe(second);
   });
 
-  it('allows login with valid otp', async () => {
+  it('allows login with valid idToken', async () => {
+    verifyMock.mockResolvedValue({ uid: 'f1', email: 't@test.com' });
     (User.findOne as jest.Mock).mockResolvedValue({ id: 'u1', name: 'Test', email: 't@test.com' });
-    await request(app).post('/send-otp').send({ phone: '+10000000003' });
-    const code = otpService._getOtp('+10000000003')!;
-    const res = await request(app)
-      .post('/login')
-      .send({ identifier: '+10000000003', credential: code });
+
+    const res = await request(app).post('/login').send({ idToken: 'good' });
+
     expect(res.status).toBe(200);
+    expect(verifyMock).toHaveBeenCalledWith('good');
     expect(res.body.token).toBeDefined();
   });
 
-  it('rejects login with invalid otp', async () => {
-    (User.findOne as jest.Mock).mockResolvedValue({ id: 'u1', name: 'Test', email: 't@test.com' });
-    await request(app).post('/send-otp').send({ phone: '+10000000004' });
-    const res = await request(app)
-      .post('/login')
-      .send({ identifier: '+10000000004', credential: '000000' });
+  it('rejects login with invalid idToken', async () => {
+    verifyMock.mockRejectedValue(new Error('bad'));
+
+    const res = await request(app).post('/login').send({ idToken: 'bad' });
+
     expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary
- allow idToken-based login via Firebase for users and organizers
- keep admin login by credential
- fix admin route file and tests
- update auth tests to mock Firebase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e1d58caa88328af7ba798bf199f2c