### PR TITLE
Implement dual signup modes

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -11,7 +11,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -30,16 +30,18 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useToast } from "@/hooks/use-toast";
-import { Loader2, Phone } from "lucide-react";
+import { Loader2, Mail, Phone } from "lucide-react";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { auth } from "@/lib/firebase";
+import { RecaptchaVerifier, signInWithPhoneNumber, ConfirmationResult, createUserWithEmailAndPassword } from "firebase/auth";
 
 
 const SignupFormSchema = z.object({
   name: z.string().min(3, "Full name must be at least 3 characters."),
-  email: z.string().email("Please enter a valid email address."),
-  phone: z.string().min(10, "Please enter a valid 10-digit phone number."),
+  email: z.string().email("Please enter a valid email address.").optional(),
+  phone: z.string().min(10, "Please enter a valid 10-digit phone number.").optional(),
   accountType: z.enum(["USER", "ORGANIZER"], { required_error: "You must select an account type." }),
   referralCode: z.string().optional(),
   terms: z.literal(true, {
@@ -55,6 +57,21 @@ export default function SignupPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [countryCode, setCountryCode] = useState('+91');
 
+  const [signupMode, setSignupMode] = useState<'phone' | 'email'>('phone');
+  const isEmailMode = signupMode === 'email';
+  const recaptcha = useRef<RecaptchaVerifier>();
+  const [confirmationResult, setConfirmationResult] = useState<ConfirmationResult | null>(null);
+  const [otp, setOtp] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!recaptcha.current) {
+      recaptcha.current = new RecaptchaVerifier(auth, 'signup-recaptcha', { size: 'invisible' });
+    }
+  }, []);
+
   const form = useForm<SignupFormData>({
     resolver: zodResolver(SignupFormSchema),
     defaultValues: {
@@ -67,31 +84,59 @@ export default function SignupPage() {
     },
   });
 
+  const submitToBackend = async (uid: string, data: SignupFormData) => {
+    const payload = { ...data, phone: `${countryCode}${data.phone}`, uid };
+    const response = await fetch('/api/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    const result = await response.json();
+
+    if (!response.ok) {
+      throw new Error(result.message || 'Signup failed.');
+    }
+
+    toast({
+      title: 'Account Created!',
+      description: 'Your account has been created successfully. Please log in to continue.',
+    });
+    router.push('/auth/login');
+  };
+
   const handleSignup = async (data: SignupFormData) => {
     setIsLoading(true);
     try {
-      const payload = {
-        ...data,
-        phone: `${countryCode}${data.phone}`
+      if (signupMode === 'phone' && !data.phone) {
+        throw new Error('Phone number is required for phone signup.');
       }
-      const response = await fetch('/api/auth/signup', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-
-      const result = await response.json();
-
-      if (!response.ok) {
-        throw new Error(result.message || 'Signup failed.');
+      if (signupMode === 'email' && !data.email) {
+        throw new Error('Email is required for email signup.');
       }
-
-      toast({
-        title: "Account Created!",
-        description: "Your account has been created successfully. Please log in to continue.",
-      });
-      router.push('/auth/login');
-
+      if (signupMode === 'phone') {
+        if (!confirmationResult) {
+          const fullPhone = `${countryCode}${data.phone}`;
+          const result = await signInWithPhoneNumber(auth, fullPhone, recaptcha.current!);
+          setConfirmationResult(result);
+          toast({ title: 'OTP Sent', description: `A verification code has been sent to ${fullPhone}.` });
+          return;
+        }
+        if (otp.length !== 6) {
+          throw new Error('Please enter the 6-digit OTP.');
+        }
+        const cred = await confirmationResult.confirm(otp);
+        await submitToBackend(cred.user.uid, data);
+      } else {
+        if (password.length < 6) {
+          throw new Error('Password must be at least 6 characters.');
+        }
+        if (password !== confirmPassword) {
+          throw new Error('Passwords do not match.');
+        }
+        const cred = await createUserWithEmailAndPassword(auth, data.email, password);
+        await submitToBackend(cred.user.uid, data);
+      }
     } catch (error: any) {
       toast({
         variant: 'destructive',
@@ -115,6 +160,12 @@ export default function SignupPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-4">
+            <div className="flex w-full items-center gap-2">
+              <Button variant="outline" size="sm" type="button" onClick={() => setSignupMode(isEmailMode ? 'phone' : 'email')} className="ml-auto">
+                {isEmailMode ? <Phone className="mr-2 h-4 w-4" /> : <Mail className="mr-2 h-4 w-4" />}
+                Sign up with {isEmailMode ? 'Phone' : 'Email'}
+              </Button>
+            </div>
             
             <FormField
               control={form.control}
@@ -148,41 +199,74 @@ export default function SignupPage() {
             />
 
             <FormField control={form.control} name="name" render={({ field }) => (<FormItem><FormLabel>Full Name / Brand Name</FormLabel><FormControl><Input placeholder="John Doe" {...field} /></FormControl><FormMessage /></FormItem>)} />
-            <FormField control={form.control} name="email" render={({ field }) => (<FormItem><FormLabel>Email Address</FormLabel><FormControl><Input type="email" placeholder="m@example.com" {...field} /></FormControl><FormMessage /></FormItem>)} />
-            
-            <FormField
-              control={form.control}
-              name="phone"
-              render={({ field }) => (
+
+            {isEmailMode && (
+              <FormField control={form.control} name="email" render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Phone Number</FormLabel>
+                  <FormLabel>Email Address</FormLabel>
                   <FormControl>
-                    <div className="flex items-center border rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
-                        <Select value={countryCode} onValueChange={setCountryCode}>
-                            <SelectTrigger className="w-[100px] border-0 shadow-none focus:ring-0">
-                                <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="+91">IN +91</SelectItem>
-                            </SelectContent>
-                        </Select>
-                        <div className="h-6 w-px bg-border" />
-                        <div className="relative flex-1">
-                            <Phone className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                            <Input
-                              type="tel"
-                              placeholder="98765 43210"
-                              className="border-0 shadow-none pl-10 focus-visible:ring-0"
-                              {...field}
-                            />
-                        </div>
-                    </div>
+                    <Input type="email" placeholder="m@example.com" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
-              )}
-            />
+              )} />
+            )}
+
+            {!isEmailMode && (
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Phone Number</FormLabel>
+                    <FormControl>
+                      <div className="flex items-center border rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
+                          <Select value={countryCode} onValueChange={setCountryCode}>
+                              <SelectTrigger className="w-[100px] border-0 shadow-none focus:ring-0">
+                                  <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                  <SelectItem value="+91">IN +91</SelectItem>
+                              </SelectContent>
+                          </Select>
+                          <div className="h-6 w-px bg-border" />
+                          <div className="relative flex-1">
+                              <Phone className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                              <Input
+                                type="tel"
+                                placeholder="98765 43210"
+                                className="border-0 shadow-none pl-10 focus-visible:ring-0"
+                                {...field}
+                              />
+                          </div>
+                      </div>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
             <FormField control={form.control} name="referralCode" render={({ field }) => (<FormItem><FormLabel>Referral Code (Optional)</FormLabel><FormControl><Input placeholder="Enter referral code" {...field} /></FormControl><FormMessage /></FormItem>)} />
+
+            {isEmailMode && (
+              <>
+                <div className="grid gap-2">
+                  <Label htmlFor="password">Password</Label>
+                  <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="confirm">Confirm Password</Label>
+                  <Input id="confirm" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required />
+                </div>
+              </>
+            )}
+
+            {!isEmailMode && confirmationResult && (
+              <div className="grid gap-2">
+                <Label htmlFor="otp">One-Time Password (OTP)</Label>
+                <Input id="otp" value={otp} onChange={(e) => setOtp(e.target.value)} maxLength={6} pattern="[0-9]*" required />
+              </div>
+            )}
             
             <FormField
               control={form.control}
@@ -208,7 +292,7 @@ export default function SignupPage() {
           <CardFooter className="flex flex-col gap-4">
             <Button className="w-full" type="submit" disabled={isLoading}>
                 {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                Create Account
+                {signupMode === 'phone' ? (confirmationResult ? 'Verify & Create Account' : 'Send OTP') : 'Create Account'}
             </Button>
             <p className="text-center text-sm text-muted-foreground">
               Already have an account?{' '}
@@ -219,6 +303,7 @@ export default function SignupPage() {
           </CardFooter>
         </form>
       </Form>
+      <div id="signup-recaptcha" />
     </Card>
   );
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,12 @@
+import { initializeApp, getApps } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+export const auth = getAuth(app);


### PR DESCRIPTION
## Summary
- add Firebase client initialization
- update signup page to support phone or email signup
- send Firebase user UID to signup API
- provide OTP and password validation logic

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e1d5b841c8328b6b63261c992acb9