### PR TITLE
Add admin login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Travonex is a multi-faceted travel platform designed to connect adventurous trav
 
 1.  **User Panel:** For travelers to explore, book, and manage trips.
 2.  **Trip Organizer Panel:** For vendors to create listings, manage bookings, and track earnings.
-3.  **Super Admin Panel:** For platform administrators to oversee all operations, from user management to financial reporting.
+3.  **Super Admin Panel:** For platform administrators to oversee all operations, from user management to financial reporting. Access the admin panel by signing in at `/admin/login`.
 
 ## Getting Started
 

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Loader2 } from 'lucide-react';
+import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+
+export default function AdminLoginPage() {
+  const { login } = useAuth();
+  const { toast } = useToast();
+
+  const [email, setEmail] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    try {
+      const { redirectPath } = await login(email, password);
+      toast({ title: 'Login Successful', description: 'Redirecting...' });
+      window.location.href = redirectPath || '/admin/dashboard';
+    } catch (error: any) {
+      toast({
+        variant: 'destructive',
+        title: 'Login Failed',
+        description: error.message || 'Invalid credentials. Please try again.',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card className="w-full max-w-sm shadow-2xl">
+      <form onSubmit={handleSubmit}>
+        <CardHeader>
+          <CardTitle className="text-2xl font-headline">Admin Sign In</CardTitle>
+          <CardDescription>Enter your admin email and password.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          <div className="grid gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-4">
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Sign In
+          </Button>
+          <p className="text-center text-sm text-muted-foreground pt-4">
+            <Link href="/auth/login" className="font-semibold text-primary hover:underline">
+              Regular user? Click here
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -43,6 +43,11 @@ export function Footer() {
                 Are you a Trip Organizer? <Link href="/auth/login" className="font-bold text-primary hover:underline">Click here to Sign In</Link>.
               </p>
             )}
+            {!user && (
+              <p className="text-sm text-muted-foreground">
+                Admins can <Link href="/admin/login" className="font-bold text-primary hover:underline">sign in here</Link>.
+              </p>
+            )}
             {/* DEV_COMMENT: This link is now conditionally rendered. It only appears to logged-in regular users. */}
              {user?.role === 'USER' && (
                  <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- implement admin login page with a simple email/password form
- link to admin sign-in from the footer
- document the admin login URL in the README

## Testing
- `npm run lint` *(fails: interactive ESLint prompt)*
- `npm run typecheck` *(fails: several TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e1d5c65988328922fd57b8694df54