### PR TITLE
Add storage helper

### DIFF
--- a/backend/src/services/storage.ts
+++ b/backend/src/services/storage.ts
@@ -1,0 +1,16 @@
+import admin from 'firebase-admin';
+
+const bucket = admin.storage().bucket();
+
+/**
+ * Upload a file buffer to Firebase Storage and return the public URL.
+ * @param buffer - File contents.
+ * @param destinationPath - Destination path inside the bucket.
+ * @returns Public URL of the uploaded file.
+ */
+export async function uploadFile(buffer: Buffer, destinationPath: string): Promise<string> {
+  const file = bucket.file(destinationPath);
+  await file.save(buffer);
+  await file.makePublic();
+  return file.publicUrl();
+}


### PR DESCRIPTION
## Summary
- create storage service with uploadFile helper for Firebase storage

## Testing
- `npm install --prefix backend`
- `npm test --prefix backend` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_686e35c75b248328bafe84361d5bb537