### PR TITLE
Enable file uploads with multer

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "mongoose": "^7.6.0",
     "razorpay": "^2.9.6",
     "jsonwebtoken": "^9.0.2",
-    "socket.io": "^4.7.5"
+    "socket.io": "^4.7.5",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.6",

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response, NextFunction } from 'express';
+import multer from 'multer';
 import Booking from '../models/booking';
 import Payout from '../models/payout';
 import User from '../models/user';
@@ -14,8 +15,10 @@ import Interest from '../models/interest';
 import City from '../models/city';
 import AdminUser from '../models/adminUser';
 import { verifyJwt } from '../middleware/verifyJwt';
+import { uploadFile } from '../services/upload';
 
 const router = express.Router();
+const upload = multer({ dest: 'tmp/' });
 router.use(verifyJwt('ADMIN'));
 
 async function logAction(
@@ -307,19 +310,27 @@ router.get('/banners', (_req, res, next) => {
     .catch(next);
 });
 
-router.post('/banners', (req, res, next) => {
-  Banner.create(req.body)
-    .then(b => res.status(201).json(b))
-    .catch(next);
+router.post('/banners', upload.single('image'), async (req, res, next) => {
+  try {
+    const data: any = { title: req.body.title, linkUrl: req.body.linkUrl };
+    if (req.file) data.imageUrl = await uploadFile(req.file);
+    const banner = await Banner.create(data);
+    res.status(201).json(banner);
+  } catch (err) {
+    next(err);
+  }
 });
 
-router.put('/banners/:id', (req, res, next) => {
-  Banner.findByIdAndUpdate(req.params.id, req.body, { new: true })
-    .then(b => {
-      if (!b) return res.status(404).json({ message: 'Banner not found' });
-      res.json(b);
-    })
-    .catch(next);
+router.put('/banners/:id', upload.single('image'), async (req, res, next) => {
+  try {
+    const update: any = { title: req.body.title, linkUrl: req.body.linkUrl };
+    if (req.file) update.imageUrl = await uploadFile(req.file);
+    const banner = await Banner.findByIdAndUpdate(req.params.id, update, { new: true });
+    if (!banner) return res.status(404).json({ message: 'Banner not found' });
+    res.json(banner);
+  } catch (err) {
+    next(err);
+  }
 });
 
 router.delete('/banners/:id', (req, res, next) => {

--- a/backend/src/routes/organizerProfile.ts
+++ b/backend/src/routes/organizerProfile.ts
@@ -1,8 +1,11 @@
 import express from 'express';
+import multer from 'multer';
 import Organizer from '../models/organizer';
 import { verifyJwt } from '../middleware/verifyJwt';
+import { uploadFile } from '../services/upload';
 
 const router = express.Router();
+const upload = multer({ dest: 'tmp/' });
 router.use(verifyJwt('ORGANIZER'));
 
 router.put('/:id/profile', async (req, res, next) => {
@@ -16,10 +19,12 @@ router.put('/:id/profile', async (req, res, next) => {
   }
 });
 
-router.post('/:id/documents', async (req, res, next) => {
+router.post('/:id/documents', upload.single('file'), async (req, res, next) => {
   if (req.params.id !== (req as any).authUser.id) return res.status(403).json({ message: 'Forbidden' });
   try {
-    const { docType, docTitle, fileUrl } = req.body;
+    const { docType, docTitle } = req.body;
+    if (!req.file) return res.status(400).json({ message: 'File is required' });
+    const fileUrl = await uploadFile(req.file);
     const organizer = await Organizer.findById(req.params.id);
     if (!organizer) return res.status(404).json({ message: 'Organizer not found' });
     const existing = organizer.documents.find(d => d.docType === docType);

--- a/backend/src/routes/trips.ts
+++ b/backend/src/routes/trips.ts
@@ -1,9 +1,12 @@
 import express from 'express';
+import multer from 'multer';
 import Trip from '../models/trip';
 import Organizer from '../models/organizer';
 import { verifyJwt } from '../middleware/verifyJwt';
+import { uploadFile } from '../services/upload';
 
 const router = express.Router();
+const upload = multer({ dest: 'tmp/' });
 
 // List trips with optional filters
 router.get('/', async (req, res, next) => {
@@ -21,9 +24,9 @@ router.get('/', async (req, res, next) => {
 });
 
 // Create a trip (organizer)
-router.post('/', verifyJwt('ORGANIZER'), async (req, res, next) => {
+router.post('/', verifyJwt('ORGANIZER'), upload.single('image'), async (req, res, next) => {
   try {
-    const data = {
+    const data: any = {
       ...req.body,
       organizerId: (req as any).authUser.id,
       batches: (req.body.batches || []).map((b: any) => ({
@@ -31,6 +34,7 @@ router.post('/', verifyJwt('ORGANIZER'), async (req, res, next) => {
         availableSlots: b.availableSlots ?? b.maxParticipants,
       })),
     };
+    if (req.file) data.image = await uploadFile(req.file);
     const trip = await Trip.create(data);
     res.status(201).json(trip);
   } catch (err) {
@@ -39,7 +43,7 @@ router.post('/', verifyJwt('ORGANIZER'), async (req, res, next) => {
 });
 
 // Update a trip (organizer)
-router.put('/:id', verifyJwt('ORGANIZER'), async (req, res, next) => {
+router.put('/:id', verifyJwt('ORGANIZER'), upload.single('image'), async (req, res, next) => {
   try {
     const update: any = { ...req.body };
     if (update.batches) {
@@ -48,6 +52,7 @@ router.put('/:id', verifyJwt('ORGANIZER'), async (req, res, next) => {
         availableSlots: b.availableSlots ?? b.maxParticipants,
       }));
     }
+    if (req.file) update.image = await uploadFile(req.file);
     const trip = await Trip.findOneAndUpdate(
       { _id: req.params.id, organizerId: (req as any).authUser.id },
       update,
@@ -79,9 +84,9 @@ router.patch('/:id/status', verifyJwt('ORGANIZER'), async (req, res, next) => {
 
 
 // Create a trip (organizer)
-router.post('/', verifyJwt('ORGANIZER'), async (req, res, next) => {
+router.post('/', verifyJwt('ORGANIZER'), upload.single('image'), async (req, res, next) => {
   try {
-    const data = {
+    const data: any = {
       ...req.body,
       organizerId: (req as any).authUser.id,
       batches: (req.body.batches || []).map((b: any) => ({
@@ -89,6 +94,7 @@ router.post('/', verifyJwt('ORGANIZER'), async (req, res, next) => {
         availableSlots: b.availableSlots ?? b.maxParticipants,
       })),
     };
+    if (req.file) data.image = await uploadFile(req.file);
     const trip = await Trip.create(data);
     res.status(201).json(trip);
   } catch (err) {
@@ -97,7 +103,7 @@ router.post('/', verifyJwt('ORGANIZER'), async (req, res, next) => {
 });
 
 // Update a trip (organizer)
-router.put('/:id', verifyJwt('ORGANIZER'), async (req, res, next) => {
+router.put('/:id', verifyJwt('ORGANIZER'), upload.single('image'), async (req, res, next) => {
   try {
     const update: any = { ...req.body };
     if (update.batches) {
@@ -106,6 +112,7 @@ router.put('/:id', verifyJwt('ORGANIZER'), async (req, res, next) => {
         availableSlots: b.availableSlots ?? b.maxParticipants,
       }));
     }
+    if (req.file) update.image = await uploadFile(req.file);
     const trip = await Trip.findOneAndUpdate(
       { _id: req.params.id, organizerId: (req as any).authUser.id },
       update,
@@ -153,7 +160,7 @@ router.post('/', verifyJwt('ORGANIZER'), async (req, res, next) => {
 });
 
 // Update a trip (organizer)
-router.put('/:id', verifyJwt('ORGANIZER'), async (req, res, next) => {
+router.put('/:id', verifyJwt('ORGANIZER'), upload.single('image'), async (req, res, next) => {
   try {
     const update: any = { ...req.body };
     if (update.batches) {
@@ -162,6 +169,7 @@ router.put('/:id', verifyJwt('ORGANIZER'), async (req, res, next) => {
         availableSlots: b.availableSlots ?? b.maxParticipants,
       }));
     }
+    if (req.file) update.image = await uploadFile(req.file);
     const trip = await Trip.findOneAndUpdate(
       { _id: req.params.id, organizerId: (req as any).authUser.id },
       update,

--- a/backend/src/services/upload.ts
+++ b/backend/src/services/upload.ts
@@ -1,0 +1,15 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function uploadFile(file: Express.Multer.File): Promise<string> {
+  // In a real application, integrate with cloud storage here.
+  // For development we just move the file to a temporary uploads directory
+  // and return a placeholder URL.
+  const uploadsDir = path.join(__dirname, '../../uploads');
+  await fs.mkdir(uploadsDir, { recursive: true });
+  const destPath = path.join(uploadsDir, file.filename);
+  await fs.rename(file.path, destPath);
+
+  // Return placeholder URL referencing the stored file
+  return `https://placehold.co/600x400?text=${encodeURIComponent(file.originalname)}`;
+}


### PR DESCRIPTION
## Summary
- add multer dependency
- add helper to fake file uploads
- accept multipart uploads on organizer documents
- add banner image upload support
- allow trip image uploads

## Testing
- `npm test` *(fails: duplicate identifiers in models and missing types)*

------
https://chatgpt.com/codex/tasks/task_e_686e35c822888328b14b4ddaea3abc57