### PR TITLE
Implement upload utility and integrate uploads

### DIFF
--- a/src/app/admin/banner-manager/page.tsx
+++ b/src/app/admin/banner-manager/page.tsx
@@ -23,13 +23,24 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { PlusCircle, Edit, Trash2 } from "lucide-react";
 import { homeBanners as mockBanners } from "@/lib/mock-data";
 import type { HomeBanner } from "@/lib/types";
 import Image from "next/image";
+import { uploadFile } from "@/lib/upload";
 
 export default function AdminBannerManagerPage() {
   const [banners, setBanners] = React.useState<HomeBanner[]>(mockBanners);
+
+  const handleAddBanner = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const url = await uploadFile(file, `banners/${Date.now()}-${file.name}`);
+    const newBanner: HomeBanner = { id: `banner-${Date.now()}`, title: file.name, imageUrl: url, linkUrl: '#', isActive: true };
+    setBanners([...banners, newBanner]);
+  };
 
   const handleStatusToggle = (id: string, newStatus: boolean) => {
     // BACKEND: Call `PUT /api/admin/banners/{id}` with `{ isActive: newStatus }`
@@ -47,8 +58,11 @@ export default function AdminBannerManagerPage() {
             Manage homepage banners, featured content, and global alerts.
             </p>
         </div>
-        {/* BACKEND: This should open a dialog to create a new banner record. POST /api/admin/banners */}
-        <Button size="lg"><PlusCircle className="mr-2"/> Add Banner</Button>
+        <Label htmlFor="banner-upload" className="sr-only">Add Banner</Label>
+        <Input id="banner-upload" type="file" accept="image/*" className="hidden" onChange={handleAddBanner} />
+        <Button asChild size="lg">
+          <label htmlFor="banner-upload" className="flex items-center cursor-pointer"><PlusCircle className="mr-2"/> Add Banner</label>
+        </Button>
       </div>
 
       <Card>

--- a/src/app/trip-organiser/profile/page.tsx
+++ b/src/app/trip-organiser/profile/page.tsx
@@ -43,6 +43,7 @@ import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, For
 import Image from 'next/image';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { useAuth } from "@/context/AuthContext";
+import { uploadFile } from "@/lib/upload";
 import { Skeleton } from "@/components/ui/skeleton";
 
 // Zod schema for profile form validation.
@@ -82,7 +83,7 @@ function DocumentPreviewDialog({ doc, isOpen, onOpenChange }: { doc: OrganizerDo
 }
 
 // Component to render individual file upload items.
-const FileUploadItem = ({ doc, onUpload, onView, disabled }: { doc: OrganizerDocument; onUpload: (docType: string) => void; onView: (doc: OrganizerDocument) => void; disabled: boolean; }) => (
+const FileUploadItem = ({ doc, onUpload, onView, disabled }: { doc: OrganizerDocument; onUpload: (docType: string, file: File) => void; onView: (doc: OrganizerDocument) => void; disabled: boolean; }) => (
     <div className="flex items-center justify-between rounded-lg border p-4">
         <div>
             <p className="font-medium">{doc.docTitle}</p>
@@ -110,10 +111,15 @@ const FileUploadItem = ({ doc, onUpload, onView, disabled }: { doc: OrganizerDoc
                 </div>
             )}
             {(doc.status === 'Pending' || doc.status === 'Rejected') && (
-                 <Button variant="outline" size="sm" onClick={() => onUpload(doc.docType)} disabled={disabled}>
-                    <UploadCloud className="mr-2 h-4 w-4" />
-                    Upload
-                </Button>
+                <>
+                    <Label htmlFor={`doc-${doc.docType}`} className="sr-only">Upload</Label>
+                    <Input id={`doc-${doc.docType}`} type="file" className="hidden" accept="application/pdf,image/*" onChange={(e) => e.target.files && onUpload(doc.docType, e.target.files[0])} disabled={disabled} />
+                    <Button asChild variant="outline" size="sm" disabled={disabled}>
+                        <label htmlFor={`doc-${doc.docType}`} className="flex items-center">
+                            <UploadCloud className="mr-2 h-4 w-4" />Upload
+                        </label>
+                    </Button>
+                </>
             )}
         </div>
     </div>
@@ -213,12 +219,12 @@ export default function OrganizerProfilePage() {
     form.formState.isSubmitting = false;
   };
   
-  const handleDocumentUpload = (docType: string) => {
-    if (!organizer) return;
-    console.log("Uploading document of type:", docType);
+  const handleDocumentUpload = async (docType: string, file: File) => {
+    if (!organizer || !file) return;
+    const url = await uploadFile(file, `documents/${organizer.id}/${docType}-${Date.now()}`);
     setOrganizer(prev => prev ? {
         ...prev,
-        documents: prev.documents.map(doc => doc.docType === docType ? { ...doc, status: 'Uploaded', fileUrl: '/invoices/invoice.pdf' } : doc)
+        documents: prev.documents.map(doc => doc.docType === docType ? { ...doc, status: 'Uploaded', fileUrl: url } : doc)
     } : null);
     toast({ title: "Document Uploaded", description: "Your document is now ready for verification." });
   };
@@ -228,9 +234,11 @@ export default function OrganizerProfilePage() {
     setIsDocPreviewOpen(true);
   };
   
-  const handleUploadAgreement = () => {
+  const handleUploadAgreement = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!organizer) return;
-    console.log("Uploading signed agreement...");
+    const file = e.target.files?.[0];
+    if (!file) return;
+    await uploadFile(file, `agreements/${organizer.id}-${Date.now()}`);
     setOrganizer(prev => prev ? { ...prev, vendorAgreementStatus: 'Submitted' } : null);
     toast({ title: "Agreement Uploaded", description: "Your signed agreement is now ready for verification." });
   };

--- a/src/components/trips/TripForm.tsx
+++ b/src/components/trips/TripForm.tsx
@@ -32,7 +32,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { UploadCloud, PlusCircle, Trash2, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import React, { useState } from "react";
 import { useCity } from "@/context/CityContext";
 import { Switch } from "@/components/ui/switch";
 import { DatePicker } from "@/components/ui/datepicker";
@@ -40,6 +40,7 @@ import { Label } from "@/components/ui/label";
 import { interests as mockInterests, categories as mockCategories } from "@/lib/mock-data";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { uploadFile } from "@/lib/upload";
 
 
 interface TripFormProps {
@@ -113,6 +114,8 @@ const TripFormSchema = z.object({
       question: z.string().min(1, "Question cannot be empty"),
       answer: z.string().min(1, "Answer cannot be empty"),
   })).optional(),
+  image: z.string().optional(),
+  gallery: z.array(z.string()).optional(),
 });
 
 type TripFormData = z.infer<typeof TripFormSchema>;
@@ -126,6 +129,22 @@ export function TripForm({ trip, isAdmin = false }: TripFormProps) {
   
   const [coverImageName, setCoverImageName] = useState<string | null>(null);
   const [galleryImageNames, setGalleryImageNames] = useState<string[]>([]);
+
+  const handleCoverUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setCoverImageName(file.name);
+    const url = await uploadFile(file, `trips/cover-${Date.now()}-${file.name}`);
+    form.setValue('image', url);
+  };
+
+  const handleGalleryUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    setGalleryImageNames(files.map(f => f.name));
+    if (files.length === 0) return;
+    const urls = await Promise.all(files.map(f => uploadFile(f, `trips/gallery-${Date.now()}-${f.name}`)));
+    form.setValue('gallery', urls);
+  };
 
   // State for the mandatory remarks dialog
   const [isRemarkDialogOpen, setIsRemarkDialogOpen] = useState(false);
@@ -155,6 +174,8 @@ export function TripForm({ trip, isAdmin = false }: TripFormProps) {
       price: trip?.price || 0,
       taxIncluded: trip?.taxIncluded || false,
       taxPercentage: trip?.taxPercentage || 0,
+      image: trip?.image || '',
+      gallery: trip?.gallery?.map(g => g.url) || [],
       inclusions: trip?.inclusions.map(v => ({value: v})) || [{ value: '' }],
       exclusions: trip?.exclusions.map(v => ({value: v})) || [{ value: '' }],
       itinerary: trip?.itinerary || [{ day: 1, title: "", description: "" }],
@@ -357,7 +378,7 @@ export function TripForm({ trip, isAdmin = false }: TripFormProps) {
                                             <UploadCloud className="w-8 h-8 mb-2 text-muted-foreground" />
                                             {coverImageName ? <p className="text-sm text-foreground font-semibold">{coverImageName}</p> : <p className="text-sm text-muted-foreground">Click to upload (Min 1200x675px)</p>}
                                         </div>
-                                        <Input id="cover-image" type="file" className="hidden" accept="image/png, image/jpeg, image/webp" onChange={(e) => setCoverImageName(e.target.files?.[0].name || null)} />
+                                        <Input id="cover-image" type="file" className="hidden" accept="image/png, image/jpeg, image/webp" onChange={handleCoverUpload} />
                                     </Label>
                                 </FormControl>
                             </FormItem>
@@ -369,7 +390,7 @@ export function TripForm({ trip, isAdmin = false }: TripFormProps) {
                                             <UploadCloud className="w-8 h-8 mb-2 text-muted-foreground" />
                                             {galleryImageNames.length > 0 ? <p className="text-sm text-foreground font-semibold">{galleryImageNames.length} image(s) selected</p> : <p className="text-sm text-muted-foreground">Click to upload (5-8 images)</p>}
                                         </div>
-                                        <Input id="gallery-images" type="file" className="hidden" multiple accept="image/png, image/jpeg, image/webp" onChange={(e) => setGalleryImageNames(Array.from(e.target.files || []).map(f => f.name))} />
+                                        <Input id="gallery-images" type="file" className="hidden" multiple accept="image/png, image/jpeg, image/webp" onChange={handleGalleryUpload} />
                                     </Label>
                                 </FormControl>
                             </FormItem>

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,18 +1,11 @@
-import { initializeApp, getApps } from 'firebase/app';
 import { initializeApp, getApps, getApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-};
-
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
-export const auth = getAuth(app);
-const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
-export const auth = getAuth(app);
   storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
@@ -20,5 +13,8 @@ export const auth = getAuth(app);
 };
 
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+
+export const auth = getAuth(app);
+export const storage = getStorage(app);
 
 export default app;

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -1,0 +1,13 @@
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { storage } from './firebase';
+
+/**
+ * Uploads a file to Firebase Storage and returns the public URL.
+ * The caller can optionally provide a path; otherwise a timestamped name is used.
+ */
+export async function uploadFile(file: File | Blob, path?: string): Promise<string> {
+  const filePath = path || `uploads/${Date.now()}-${(file as File).name ?? 'file'}`;
+  const fileRef = ref(storage, filePath);
+  await uploadBytes(fileRef, file);
+  return await getDownloadURL(fileRef);
+}


### PR DESCRIPTION
## Summary
- fix firebase initialization
- add a new `uploadFile` helper for Firebase Storage
- use upload helper in TripForm image inputs
- allow banner images to be uploaded
- upload organizer documents and agreements

## Testing
- `npm run typecheck` *(fails: cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e35ccb2f883289af1a08fd34e77f5