### PR TITLE
Switch organizer pages to API

### DIFF
--- a/src/app/api/organizers/me/bookings/route.ts
+++ b/src/app/api/organizers/me/bookings/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+
+export async function GET(request: Request) {
+  const res = await fetch(`${BACKEND_URL}/api/organizers/me/bookings`, {
+    headers: { Authorization: request.headers.get('Authorization') || '' },
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/organizers/me/payouts/route.ts
+++ b/src/app/api/organizers/me/payouts/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+
+export async function GET(request: Request) {
+  const res = await fetch(`${BACKEND_URL}/api/organizers/me/payouts`, {
+    headers: { Authorization: request.headers.get('Authorization') || '' },
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/organizers/me/route.ts
+++ b/src/app/api/organizers/me/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+
+export async function GET(request: Request) {
+  const res = await fetch(`${BACKEND_URL}/api/organizers/me`, {
+    headers: { Authorization: request.headers.get('Authorization') || '' },
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function PUT(request: Request) {
+  const res = await fetch(`${BACKEND_URL}/api/organizers/me`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: request.headers.get('Authorization') || '',
+    },
+    body: await request.text(),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/organizers/me/trips/route.ts
+++ b/src/app/api/organizers/me/trips/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+
+export async function GET(request: Request) {
+  const res = await fetch(`${BACKEND_URL}/api/organizers/me/trips`, {
+    headers: { Authorization: request.headers.get('Authorization') || '' },
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/trips/[tripId]/status/route.ts
+++ b/src/app/api/trips/[tripId]/status/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+
+export async function PATCH(request: Request, { params }: { params: { tripId: string } }) {
+  const res = await fetch(`${BACKEND_URL}/api/trips/${params.tripId}/status`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: request.headers.get('Authorization') || '',
+    },
+    body: await request.text(),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/trip-organiser/bookings/page.tsx
+++ b/src/app/trip-organiser/bookings/page.tsx
@@ -37,14 +37,13 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { bookings as mockBookings, trips, users } from "@/lib/mock-data";
-import { Users as UsersIcon, Calendar, User, Mail, Phone, Info } from "lucide-react";
+import { Users as UsersIcon, Calendar, User, Mail, Phone, Info, AlertTriangle } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
 import type { Booking } from "@/lib/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ClientOnlyDate } from "@/components/common/ClientOnlyDate";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
-// Mock organizer ID for demonstration purposes.
-const MOCK_ORGANIZER_ID = 'VND001';
 
 const BookingsSkeleton = () => (
     <div className="space-y-2">
@@ -58,19 +57,49 @@ const BookingsSkeleton = () => (
 export default function OrganizerBookingsPage() {
     const [organizerBookings, setOrganizerBookings] = React.useState<Booking[]>([]);
     const [isLoading, setIsLoading] = React.useState(true);
+    const [error, setError] = React.useState<string | null>(null);
 
+    const { token } = useAuth();
     React.useEffect(() => {
-        // FRONTEND: Simulate fetching data
-        // BACKEND: In a real app, this filtering would be done on the backend.
-        // The API (`/api/organizers/me/bookings`) should only return bookings for the authenticated organizer.
-        setIsLoading(true);
-        setTimeout(() => {
-            const organizerTripIds = trips.filter(t => t.organizerId === MOCK_ORGANIZER_ID).map(t => t.id);
-            const fetchedBookings = mockBookings.filter(b => organizerTripIds.includes(b.tripId));
-            setOrganizerBookings(fetchedBookings);
-            setIsLoading(false);
-        }, 300);
-    }, []);
+        if (!token) return;
+        const fetchBookings = async () => {
+            setIsLoading(true);
+            setError(null);
+            try {
+                const res = await fetch('/api/organizers/me/bookings', {
+                    headers: { Authorization: `Bearer ${token}` }
+                });
+                const data = await res.json();
+                if (!res.ok) throw new Error(data.message || 'Failed to fetch bookings');
+                setOrganizerBookings(data);
+            } catch (err: any) {
+                setError(err.message);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchBookings();
+    }, [token]);
+
+  if (isLoading) {
+      return (
+          <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
+              <BookingsSkeleton />
+          </main>
+      );
+  }
+
+  if (error) {
+      return (
+          <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
+              <Alert variant="destructive">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertTitle>Error Loading Bookings</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+              </Alert>
+          </main>
+      );
+  }
 
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
@@ -88,14 +117,11 @@ export default function OrganizerBookingsPage() {
           <CardDescription>A complete list of all bookings for your trips, including participant details.</CardDescription>
         </CardHeader>
         <CardContent>
-          {isLoading ? (
-            <BookingsSkeleton />
-          ) : organizerBookings.length > 0 ? (
+          {organizerBookings.length > 0 ? (
             <Accordion type="single" collapsible className="w-full">
-              {organizerBookings.map((booking) => {
-                const trip = trips.find(t => t.id === booking.tripId);
-                const user = users.find(u => u.id === booking.userId);
-                const batch = trip?.batches.find(b => b.id === booking.batchId);
+              {organizerBookings.map((booking: any) => {
+                const trip = booking.trip || {};
+                const user = booking.user || {};
                 return (
                   <AccordionItem value={booking.id} key={booking.id}>
                     <AccordionTrigger className="hover:bg-muted/50 px-4 rounded-md">
@@ -103,8 +129,8 @@ export default function OrganizerBookingsPage() {
                             <div className="flex items-center gap-4">
                                 <UsersIcon className="h-5 w-5 text-primary" />
                                 <div className="text-left">
-                                    <p className="font-semibold">{user?.name}</p>
-                                    <p className="text-muted-foreground">{trip?.title}</p>
+                                    <p className="font-semibold">{user.name}</p>
+                                    <p className="text-muted-foreground">{trip.title}</p>
                                 </div>
                             </div>
                              <div className="flex items-center gap-4 md:gap-6">

--- a/src/app/trip-organiser/payouts/page.tsx
+++ b/src/app/trip-organiser/payouts/page.tsx
@@ -36,19 +36,17 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Download, Send, CheckCircle, Loader2 } from "lucide-react";
+import { Download, Send, CheckCircle, Loader2, AlertTriangle } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import type { Payout } from "@/lib/types";
+import { useAuth } from "@/context/AuthContext";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { trips } from "@/lib/mock-data";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ClientOnlyDate } from "@/components/common/ClientOnlyDate";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
-
-// Mock Data for Prototyping
-const MOCK_ORGANIZER_ID = 'VND001';
 
 type EligibleBatch = {
     tripId: string;
@@ -61,19 +59,6 @@ type EligibleBatch = {
     netPayout: number;
 };
 
-// Represents batches that are completed and ready for payout request.
-// In a real app, this would be fetched from `GET /api/organizers/me/eligible-payouts`.
-const initialEligibleBatches: EligibleBatch[] = [
-    { tripId: '3', batchId: 'batch-3-1', tripTitle: 'Rishikesh Adventure Rush', batchDates: 'Sep 15, 2024 - Sep 19, 2024', participants: 8, grossRevenue: 1600000, commission: 160000, netPayout: 1440000 },
-    { tripId: '5', batchId: 'batch-5-1', tripTitle: 'Munnar Tea Gardens Escape', batchDates: 'Aug 10, 2024 - Aug 13, 2024', participants: 12, grossRevenue: 1728000, commission: 172800, netPayout: 1555200 },
-];
-
-// Represents payouts that have been requested or paid.
-// Fetched from `GET /api/organizers/me/payout-history`.
-const initialPayoutHistory: Payout[] = [
-    { id: 'PAY004', tripId: '6', batchId: 'batch-6-1', organizerId: MOCK_ORGANIZER_ID, requestDate: '2024-08-01', totalRevenue: 150000, platformCommission: 15000, netPayout: 135000, status: 'Paid', utrNumber: 'upi-ref-29834u', invoiceUrl: '/invoices/invoice.pdf', paidDate: '2024-08-02' },
-    { id: 'PAY002', tripId: '3', batchId: 'batch-3-1', organizerId: 'VND001', totalRevenue: 1600000, platformCommission: 160000, netPayout: 1440000, status: 'Pending', requestDate: '2024-07-18', notes: 'Awaiting organizer confirmation' }
-];
 
 // A dedicated dialog component for the payout request confirmation.
 function RequestPayoutDialog({ batch, onConfirm, disabled, disabledReason }: { batch: EligibleBatch, onConfirm: (batch: EligibleBatch, notes: string) => void, disabled: boolean, disabledReason: string }) {
@@ -154,49 +139,79 @@ const TableSkeleton = ({ columns }: { columns: number }) => (
 
 export default function OrganizerPayoutsPage() {
     const { toast } = useToast();
+    const { token, user } = useAuth();
     const [eligible, setEligible] = React.useState<EligibleBatch[]>([]);
     const [history, setHistory] = React.useState<Payout[]>([]);
     const [isLoading, setIsLoading] = React.useState(true);
+    const [error, setError] = React.useState<string | null>(null);
 
     React.useEffect(() => {
-        // FRONTEND: Simulate fetching payout data
-        // BACKEND: Should be two API calls: `GET /api/organizers/me/eligible-payouts` and `GET /api/organizers/me/payout-history`
-        setIsLoading(true);
-        setTimeout(() => {
-            setEligible(initialEligibleBatches);
-            setHistory(initialPayoutHistory);
-            setIsLoading(false);
-        }, 300);
-    }, []);
+        if (!token) return;
+        const fetchPayouts = async () => {
+            setIsLoading(true);
+            setError(null);
+            try {
+                const res = await fetch('/api/organizers/me/payouts', {
+                    headers: { Authorization: `Bearer ${token}` }
+                });
+                const data = await res.json();
+                if (!res.ok) throw new Error(data.message || 'Failed to fetch payouts');
+                setEligible(data.eligible || []);
+                setHistory(data.history || []);
+            } catch (err: any) {
+                setError(err.message);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchPayouts();
+    }, [token]);
+
+    if (isLoading) {
+        return (
+            <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
+                <TableSkeleton columns={4} />
+            </main>
+        );
+    }
+
+    if (error) {
+        return (
+            <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
+                <Alert variant="destructive">
+                    <AlertTriangle className="h-4 w-4" />
+                    <AlertTitle>Error Loading Payouts</AlertTitle>
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            </main>
+        );
+    }
 
     const availableForPayout = eligible.reduce((acc, batch) => acc + batch.netPayout, 0);
     const totalPaid = history.filter(p => p.status === 'Paid').reduce((acc, p) => acc + p.netPayout, 0);
     
-    const handleRequestConfirm = (batch: EligibleBatch, notes: string) => {
-        // API Integration Point for requesting a payout.
-        // This should call `POST /api/organizers/me/payouts/request`.
-        // On success, the backend should return the new pending payout object.
-        const newPayout: Payout = {
-            id: `PAY${Math.floor(Math.random() * 9000) + 1000}`,
-            tripId: batch.tripId,
-            batchId: batch.batchId,
-            organizerId: MOCK_ORGANIZER_ID,
-            totalRevenue: batch.grossRevenue,
-            platformCommission: batch.commission,
-            netPayout: batch.netPayout,
-            status: 'Pending',
-            requestDate: new Date().toISOString(),
-            notes: notes,
-        };
-        
-        // Simulate frontend state update
-        setHistory(prev => [newPayout, ...prev]);
-        setEligible(prev => prev.filter(b => b.batchId !== batch.batchId));
-
-        toast({
-            title: "Payout Requested!",
-            description: `Your request for ₹${batch.netPayout.toLocaleString('en-IN')} has been submitted.`,
-        });
+    const handleRequestConfirm = async (batch: EligibleBatch, notes: string) => {
+        if (!token) return;
+        try {
+            const res = await fetch('/api/organizers/me/payouts/request', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`
+                },
+                body: JSON.stringify({ tripId: batch.tripId, batchId: batch.batchId, notes })
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.message || 'Failed to request payout');
+            setHistory(prev => [data, ...prev]);
+            setEligible(prev => prev.filter(b => b.batchId !== batch.batchId));
+            toast({
+                title: "Payout Requested!",
+                description: `Your request for ₹${batch.netPayout.toLocaleString('en-IN')} has been submitted.`,
+            });
+        } catch (err: any) {
+            toast({ title: 'Error', description: err.message, variant: 'destructive' });
+        }
     };
   
     const getStatusBadge = (status: Payout['status']) => {
@@ -305,11 +320,11 @@ export default function OrganizerPayoutsPage() {
                     </TableHeader>
                     <TableBody>
                         {isLoading ? <TableSkeleton columns={6} /> : history.length > 0 ? history.map((payout) => {
-                            const trip = trips.find(b => b.id === payout.tripId);
+                            const tripTitle = (payout as any).tripTitle || 'Aggregated Payout';
                             return (
                             <TableRow key={payout.id}>
                                 <TableCell><ClientOnlyDate dateString={payout.requestDate} type="date" /></TableCell>
-                                <TableCell>{trip?.title || 'Aggregated Payout'}</TableCell>
+                                <TableCell>{tripTitle}</TableCell>
                                 <TableCell><Badge variant={'default'} className={getStatusBadge(payout.status)}>{payout.status}</Badge></TableCell>
                                 <TableCell className="font-mono text-xs">{payout.utrNumber || 'N/A'}</TableCell>
                                 <TableCell className="text-right font-mono">₹{payout.netPayout.toLocaleString('en-IN')}</TableCell>

--- a/src/app/trip-organiser/profile/page.tsx
+++ b/src/app/trip-organiser/profile/page.tsx
@@ -37,7 +37,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { UploadCloud, CheckCircle, AlertCircle, FileText, Download, ShieldCheck, ShieldAlert, ShieldX, Eye, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { organizers as mockOrganizers } from "@/lib/mock-data";
 import type { Organizer, OrganizerDocument } from "@/lib/types";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import Image from 'next/image';
@@ -186,37 +185,62 @@ export default function OrganizerProfilePage() {
 
   // Fetch organizer data based on the authenticated user session.
   React.useEffect(() => {
-      if (sessionUser) {
-          const currentOrganizer = mockOrganizers.find(o => o.id === sessionUser.id);
-          if (currentOrganizer) {
-              setOrganizer(currentOrganizer);
-              form.reset({
-                  name: currentOrganizer.name || '',
-                  organizerType: currentOrganizer.organizerType || undefined,
-                  phone: currentOrganizer.phone || '',
-                  address: currentOrganizer.address || '',
-                  website: currentOrganizer.website || '',
-                  experience: currentOrganizer.experience || 0,
-                  specializations: currentOrganizer.specializations || [],
-                  authorizedSignatoryName: currentOrganizer.authorizedSignatoryName || '',
-                  authorizedSignatoryId: currentOrganizer.authorizedSignatoryId || '',
-                  emergencyContact: currentOrganizer.emergencyContact || '',
+      if (!sessionUser) return;
+      const loadOrganizer = async () => {
+          try {
+              const res = await fetch('/api/organizers/me', {
+                  headers: { Authorization: `Bearer ${localStorage.getItem('authToken')}` }
               });
+              const data: Organizer = await res.json();
+              if (res.ok) {
+                  setOrganizer(data);
+                  form.reset({
+                      name: data.name || '',
+                      organizerType: data.organizerType || undefined,
+                      phone: data.phone || '',
+                      address: data.address || '',
+                      website: data.website || '',
+                      experience: data.experience || 0,
+                      specializations: data.specializations || [],
+                      authorizedSignatoryName: data.authorizedSignatoryName || '',
+                      authorizedSignatoryId: data.authorizedSignatoryId || '',
+                      emergencyContact: data.emergencyContact || '',
+                  });
+              }
+          } catch (err) {
+              console.error('Failed to load organizer profile', err);
           }
-      }
+      };
+      loadOrganizer();
   }, [sessionUser, form]);
 
   const handleProfileSave = async (data: ProfileFormData) => {
     if (!organizer) return;
     form.formState.isSubmitting = true;
-    console.log("Profile Save Payload:", data);
-    await new Promise(resolve => setTimeout(resolve, 300));
-    setOrganizer(prev => prev ? { ...prev, ...data, isProfileComplete: true } : null);
-    toast({
-      title: "Profile Saved!",
-      description: "Your business information has been updated. The Vendor Agreement will be sent to your registered email.",
-    });
-    form.formState.isSubmitting = false;
+    try {
+      const res = await fetch('/api/organizers/me', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('authToken')}`,
+        },
+        body: JSON.stringify(data),
+      });
+      const updated = await res.json();
+      if (res.ok) {
+        setOrganizer(updated);
+        toast({
+          title: 'Profile Saved!',
+          description: 'Your business information has been updated. The Vendor Agreement will be sent to your registered email.',
+        });
+      } else {
+        throw new Error(updated.message || 'Failed to save profile');
+      }
+    } catch (err: any) {
+      toast({ title: 'Error', description: err.message, variant: 'destructive' });
+    } finally {
+      form.formState.isSubmitting = false;
+    }
   };
   
   const handleDocumentUpload = async (docType: string, file: File) => {

--- a/src/app/trip-organiser/trips/page.tsx
+++ b/src/app/trip-organiser/trips/page.tsx
@@ -20,18 +20,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { PlusCircle, Edit, Eye, Lock, Loader2 } from "lucide-react";
-import { trips as mockTrips, bookings } from "@/lib/mock-data";
+import { PlusCircle, Edit, Eye, Lock, Loader2, AlertTriangle } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
 import type { Trip } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ClientOnlyDate } from "@/components/common/ClientOnlyDate";
 
 
-// Mock organizer ID
-const MOCK_ORGANIZER_ID = 'VND001';
 
 const getStatusBadgeVariant = (status: Trip['status']) => {
     switch (status) {
@@ -60,30 +59,84 @@ const TripsTableSkeleton = () => (
 
 
 export default function OrganizerTripsPage() {
+  const { token } = useAuth();
   const [organizerTrips, setOrganizerTrips] = React.useState<Trip[]>([]);
   const [isLoading, setIsLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
-    // FRONTEND: Simulate fetching data
-    // BACKEND: Call `GET /api/organizers/me/trips`
-    setIsLoading(true);
-    setTimeout(() => {
-        setOrganizerTrips(mockTrips.filter(t => t.organizerId === MOCK_ORGANIZER_ID));
+    if (!token) return;
+    const fetchTrips = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await fetch('/api/organizers/me/trips', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.message || 'Failed to fetch trips');
+        setOrganizerTrips(data);
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
         setIsLoading(false);
-    }, 300);
-  }, []);
+      }
+    };
+    fetchTrips();
+  }, [token]);
 
-  const handlePauseToggle = (tripId: string, isPublished: boolean) => {
-    // BACKEND: Call `PATCH /api/trips/{tripId}/status` with the new status
-    setOrganizerTrips(prevTrips => 
-        prevTrips.map(trip => 
-            trip.id === tripId 
-            ? { ...trip, status: isPublished ? 'Published' : 'Unlisted' }
-            : trip
-        )
+  const handlePauseToggle = async (tripId: string, isPublished: boolean) => {
+    if (!token) return;
+    setOrganizerTrips(prev =>
+      prev.map(trip =>
+        trip.id === tripId ? { ...trip, status: isPublished ? 'Published' : 'Unlisted' } : trip
+      )
     );
+    try {
+      await fetch(`/api/trips/${tripId}/status`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: isPublished ? 'Published' : 'Unlisted' }),
+      });
+    } catch (err) {
+      console.error('Failed to update status', err);
+    }
   };
 
+
+  if (isLoading) {
+    return (
+      <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
+        <div className="space-y-2">
+            <Skeleton className="h-10 w-1/3" />
+        </div>
+        <Card>
+          <CardContent>
+            <Table>
+              <TableBody>
+                <TripsTableSkeleton />
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Error Loading Trips</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      </main>
+    );
+  }
 
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
@@ -123,7 +176,9 @@ export default function OrganizerTripsPage() {
             </TableHeader>
             <TableBody>
               {isLoading ? <TripsTableSkeleton /> : organizerTrips.length > 0 ? organizerTrips.map((trip) => {
-                const tripBookings = bookings.filter(b => b.tripId === trip.id && b.status !== 'Cancelled');
+                const tripBookings = Array.isArray((trip as any).bookings)
+                  ? (trip as any).bookings.filter((b: any) => b.status !== 'Cancelled')
+                  : [];
                 const totalCapacity = trip.batches.reduce((acc, batch) => acc + batch.maxParticipants, 0);
                 const isEditable = trip.status === 'Draft' || trip.status === 'Published' || trip.status === 'Unlisted';
                 const nextBatch = trip.batches.filter(b => new Date(b.startDate) > new Date()).sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())[0];


### PR DESCRIPTION
## Summary
- replace mock-data with API calls in organizer pages
- add endpoints for organizer trips, bookings, payouts and profile
- add patch endpoint for trip status
- handle loading and error states across pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: several missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686e87d4da1c8328866bc2f2d489a0e4