### PR TITLE
Add reference routes

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import promotionsRoutes from './routes/promotions';
 import adminSettingsRoutes from './routes/adminSettings';
 import userRoutes from './routes/users';
 import contentRoutes from './routes/content';
+import referenceRoutes from './routes/reference';
 import { errorHandler } from './middleware/errorHandler';
 import { initSocket } from './socket';
 
@@ -50,6 +51,7 @@ app.use('/api/admin/settings', adminSettingsRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/content', contentRoutes);
 app.use('/api/coupons', couponRoutes);
+app.use('/api/reference', referenceRoutes);
 
 
 if (!admin.apps.length) {

--- a/backend/src/routes/reference.ts
+++ b/backend/src/routes/reference.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import City from '../models/city';
+import Category from '../models/category';
+import Interest from '../models/interest';
+
+const router = express.Router();
+
+router.get('/cities', (_req, res, next) => {
+  City.find({ enabled: true })
+    .then(c => res.json(c))
+    .catch(next);
+});
+
+router.get('/categories', (_req, res, next) => {
+  Category.find({ status: 'Active' })
+    .then(c => res.json(c))
+    .catch(next);
+});
+
+router.get('/interests', (_req, res, next) => {
+  Interest.find({ status: 'Active' })
+    .then(i => res.json(i))
+    .catch(next);
+});
+
+export default router;

--- a/backend/tests/routes/reference.test.ts
+++ b/backend/tests/routes/reference.test.ts
@@ -1,0 +1,38 @@
+import request from 'supertest';
+import express from 'express';
+
+import router from '../../src/routes/reference';
+import City from '../../src/models/city';
+import Category from '../../src/models/category';
+import Interest from '../../src/models/interest';
+
+jest.mock('../../src/models/city');
+jest.mock('../../src/models/category');
+jest.mock('../../src/models/interest');
+
+const app = express();
+app.use(express.json());
+app.use(router);
+
+describe('reference routes', () => {
+  it('lists cities', async () => {
+    (City.find as jest.Mock).mockResolvedValue([]);
+    const res = await request(app).get('/cities');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('lists categories', async () => {
+    (Category.find as jest.Mock).mockResolvedValue([]);
+    const res = await request(app).get('/categories');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('lists interests', async () => {
+    (Interest.find as jest.Mock).mockResolvedValue([]);
+    const res = await request(app).get('/interests');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add reference routes for publicly available data
- mount new reference router in app
- test reference endpoints

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_686e88926c8083288f468ac720cfa73d