### PR TITLE
Add reference API routes

### DIFF
--- a/src/app/api/reference/categories/route.ts
+++ b/src/app/api/reference/categories/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+
+export async function GET(request: Request) {
+  const { search } = new URL(request.url);
+  const res = await fetch(`${BACKEND_URL}/api/reference/categories${search}`);
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/reference/cities/route.ts
+++ b/src/app/api/reference/cities/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+
+export async function GET(request: Request) {
+  const { search } = new URL(request.url);
+  const res = await fetch(`${BACKEND_URL}/api/reference/cities${search}`);
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/reference/interests/route.ts
+++ b/src/app/api/reference/interests/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+
+export async function GET(request: Request) {
+  const { search } = new URL(request.url);
+  const res = await fetch(`${BACKEND_URL}/api/reference/interests${search}`);
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}


### PR DESCRIPTION
## Summary
- add `cities`, `categories`, and `interests` API routes under `/api/reference`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module 'next' or other type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686e8896537c83289ded1068e06c6726