### PR TITLE
Fetch city data from API

### DIFF
--- a/src/context/CityContext.tsx
+++ b/src/context/CityContext.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import type { City } from '@/lib/types';
-import { cities as mockCities } from '@/lib/mock-data';
-import React, { createContext, useContext, useState, useMemo } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
 type CityContextType = {
   cities: City[];
@@ -14,9 +13,20 @@ const CityContext = createContext<CityContextType | undefined>(undefined);
 
 export const CityProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [selectedCity, setSelectedCity] = useState<string>('all');
-  
-  // In a real app, this would be fetched from an API
-  const cities = useMemo(() => ([{ id: 'all', name: 'All Cities', enabled: true }, ...mockCities.filter(c => c.enabled)]), []);
+  const [cities, setCities] = useState<City[]>([{ id: 'all', name: 'All Cities', enabled: true }]);
+
+  useEffect(() => {
+    async function fetchCities() {
+      try {
+        const response = await fetch('/api/reference/cities');
+        const data: City[] = await response.json();
+        setCities([{ id: 'all', name: 'All Cities', enabled: true }, ...(data || []).filter(c => c.enabled)]);
+      } catch (err) {
+        console.error('Failed to fetch cities', err);
+      }
+    }
+    fetchCities();
+  }, []);
 
   const value = useMemo(() => ({
     cities,


### PR DESCRIPTION
## Summary
- load cities from `/api/reference/cities` when `CityProvider` mounts
- remove local mock city import and adapt provider

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck` *(fails: several type errors)*
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e8898315c83289107d10b87c6ce2d