### PR TITLE
Start replacing mock data

### DIFF
--- a/src/app/trip-organiser/bookings/page.tsx
+++ b/src/app/trip-organiser/bookings/page.tsx
@@ -37,11 +37,12 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { bookings as mockBookings, trips, users } from "@/lib/mock-data";
+import { fetchData } from "@/lib/api";
 import { Users as UsersIcon, Calendar, User, Mail, Phone, Info } from "lucide-react";
-import type { Booking } from "@/lib/types";
+import type { Booking, Trip, User as AppUser } from "@/lib/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ClientOnlyDate } from "@/components/common/ClientOnlyDate";
+import { fetchData } from "@/lib/api";
 
 // Mock organizer ID for demonstration purposes.
 const MOCK_ORGANIZER_ID = 'VND001';
@@ -57,19 +58,29 @@ const BookingsSkeleton = () => (
 
 export default function OrganizerBookingsPage() {
     const [organizerBookings, setOrganizerBookings] = React.useState<Booking[]>([]);
+    const [trips, setTrips] = React.useState<Trip[]>([]);
+    const [users, setUsers] = React.useState<AppUser[]>([]);
     const [isLoading, setIsLoading] = React.useState(true);
 
     React.useEffect(() => {
-        // FRONTEND: Simulate fetching data
-        // BACKEND: In a real app, this filtering would be done on the backend.
-        // The API (`/api/organizers/me/bookings`) should only return bookings for the authenticated organizer.
         setIsLoading(true);
-        setTimeout(() => {
-            const organizerTripIds = trips.filter(t => t.organizerId === MOCK_ORGANIZER_ID).map(t => t.id);
-            const fetchedBookings = mockBookings.filter(b => organizerTripIds.includes(b.tripId));
-            setOrganizerBookings(fetchedBookings);
-            setIsLoading(false);
-        }, 300);
+        Promise.all([
+            fetchData<Booking[]>('/api/admin/bookings'),
+            fetchData<Trip[]>('/api/trips'),
+            fetchData<AppUser[]>('/api/admin/users'),
+        ])
+        .then(([bookingData, tripData, userData]) => {
+            const organizerTripIds = tripData.filter(t => t.organizerId === MOCK_ORGANIZER_ID).map(t => t.id);
+            setOrganizerBookings(bookingData.filter(b => organizerTripIds.includes(b.tripId)));
+            setTrips(tripData);
+            setUsers(userData);
+        })
+        .catch(() => {
+            setOrganizerBookings([]);
+            setTrips([]);
+            setUsers([]);
+        })
+        .finally(() => setIsLoading(false));
     }, []);
 
   return (

--- a/src/app/trip-organiser/payouts/page.tsx
+++ b/src/app/trip-organiser/payouts/page.tsx
@@ -41,7 +41,7 @@ import { useToast } from "@/hooks/use-toast";
 import type { Payout } from "@/lib/types";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { trips } from "@/lib/mock-data";
+import { fetchData } from "@/lib/api";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ClientOnlyDate } from "@/components/common/ClientOnlyDate";
@@ -156,17 +156,27 @@ export default function OrganizerPayoutsPage() {
     const { toast } = useToast();
     const [eligible, setEligible] = React.useState<EligibleBatch[]>([]);
     const [history, setHistory] = React.useState<Payout[]>([]);
+    const [trips, setTrips] = React.useState<any[]>([]);
     const [isLoading, setIsLoading] = React.useState(true);
 
     React.useEffect(() => {
-        // FRONTEND: Simulate fetching payout data
-        // BACKEND: Should be two API calls: `GET /api/organizers/me/eligible-payouts` and `GET /api/organizers/me/payout-history`
         setIsLoading(true);
-        setTimeout(() => {
-            setEligible(initialEligibleBatches);
-            setHistory(initialPayoutHistory);
-            setIsLoading(false);
-        }, 300);
+        Promise.all([
+            fetchData<EligibleBatch[]>('/api/organizers/me/eligible-payouts'),
+            fetchData<Payout[]>('/api/organizers/me/payouts'),
+            fetchData<any[]>('/api/trips'),
+        ])
+        .then(([eligibleData, historyData, tripData]) => {
+            setEligible(eligibleData);
+            setHistory(historyData);
+            setTrips(tripData);
+        })
+        .catch(() => {
+            setEligible([]);
+            setHistory([]);
+            setTrips([]);
+        })
+        .finally(() => setIsLoading(false));
     }, []);
 
     const availableForPayout = eligible.reduce((acc, batch) => acc + batch.netPayout, 0);

--- a/src/app/trip-organiser/profile/page.tsx
+++ b/src/app/trip-organiser/profile/page.tsx
@@ -37,7 +37,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { UploadCloud, CheckCircle, AlertCircle, FileText, Download, ShieldCheck, ShieldAlert, ShieldX, Eye, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { organizers as mockOrganizers } from "@/lib/mock-data";
+import { fetchData } from "@/lib/api";
 import type { Organizer, OrganizerDocument } from "@/lib/types";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import Image from 'next/image';
@@ -187,8 +187,9 @@ export default function OrganizerProfilePage() {
   // Fetch organizer data based on the authenticated user session.
   React.useEffect(() => {
       if (sessionUser) {
-          const currentOrganizer = mockOrganizers.find(o => o.id === sessionUser.id);
-          if (currentOrganizer) {
+          fetchData<Organizer>(`/api/admin/organizers/${sessionUser.id}`)
+            .then(currentOrganizer => {
+              if (!currentOrganizer) return;
               setOrganizer(currentOrganizer);
               form.reset({
                   name: currentOrganizer.name || '',
@@ -202,7 +203,8 @@ export default function OrganizerProfilePage() {
                   authorizedSignatoryId: currentOrganizer.authorizedSignatoryId || '',
                   emergencyContact: currentOrganizer.emergencyContact || '',
               });
-          }
+            })
+            .catch(() => {});
       }
   }, [sessionUser, form]);
 

--- a/src/app/trip-organiser/reviews/page.tsx
+++ b/src/app/trip-organiser/reviews/page.tsx
@@ -9,7 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { trips, users } from "@/lib/mock-data";
+import { fetchData } from "@/lib/api";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Star } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -53,17 +53,11 @@ export default function OrganizerReviewsPage() {
     const [isLoading, setIsLoading] = React.useState(true);
 
     React.useEffect(() => {
-        // FRONTEND: Simulate fetching review data
-        // BACKEND: This should be an API call like `GET /api/organizers/me/reviews`
         setIsLoading(true);
-        setTimeout(() => {
-            const organizerTrips = trips.filter(t => t.organizerId === MOCK_ORGANIZER_ID);
-            const fetchedReviews = organizerTrips.flatMap(trip => 
-                trip.reviews.map(review => ({...review, tripTitle: trip.title}))
-            );
-            setAllReviews(fetchedReviews);
-            setIsLoading(false);
-        }, 300);
+        fetchData<ReviewWithTripTitle[]>('/api/organizers/me/reviews')
+            .then(setAllReviews)
+            .catch(() => setAllReviews([]))
+            .finally(() => setIsLoading(false));
     }, []);
 
   return (

--- a/src/app/trip-organiser/trips/[tripId]/edit/page.tsx
+++ b/src/app/trip-organiser/trips/[tripId]/edit/page.tsx
@@ -1,9 +1,11 @@
 import { TripForm } from "@/components/trips/TripForm";
-import { trips } from "@/lib/mock-data";
+import { fetchData } from "@/lib/api";
+import type { Trip } from "@/lib/types";
 import { notFound } from "next/navigation";
 
-export default function EditTripPage({ params }: { params: { tripId: string } }) {
-    const trip = trips.find(t => t.id === params.tripId);
+export default async function EditTripPage({ params }: { params: { tripId: string } }) {
+    const allTrips = await fetchData<Trip[]>('/api/trips');
+    const trip = allTrips.find(t => t.id === params.tripId);
     if (!trip) {
         notFound();
     }

--- a/src/app/trip-organiser/trips/page.tsx
+++ b/src/app/trip-organiser/trips/page.tsx
@@ -21,7 +21,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { PlusCircle, Edit, Eye, Lock, Loader2 } from "lucide-react";
-import { trips as mockTrips, bookings } from "@/lib/mock-data";
+import { fetchData } from "@/lib/api";
 import type { Trip } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -64,13 +64,11 @@ export default function OrganizerTripsPage() {
   const [isLoading, setIsLoading] = React.useState(true);
 
   React.useEffect(() => {
-    // FRONTEND: Simulate fetching data
-    // BACKEND: Call `GET /api/organizers/me/trips`
     setIsLoading(true);
-    setTimeout(() => {
-        setOrganizerTrips(mockTrips.filter(t => t.organizerId === MOCK_ORGANIZER_ID));
-        setIsLoading(false);
-    }, 300);
+    fetchData<Trip[]>(`/api/organizers/me/trips`)
+      .then(data => setOrganizerTrips(data))
+      .catch(() => setOrganizerTrips([]))
+      .finally(() => setIsLoading(false));
   }, []);
 
   const handlePauseToggle = (tripId: string, isPublished: boolean) => {

--- a/src/components/trips/TripForm.tsx
+++ b/src/components/trips/TripForm.tsx
@@ -21,7 +21,7 @@
 import { useFieldArray, useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import type { Trip } from "@/lib/types";
+import type { Trip, Category, Interest } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -32,12 +32,12 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { UploadCloud, PlusCircle, Trash2, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useRouter } from "next/navigation";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useCity } from "@/context/CityContext";
 import { Switch } from "@/components/ui/switch";
 import { DatePicker } from "@/components/ui/datepicker";
 import { Label } from "@/components/ui/label";
-import { interests as mockInterests, categories as mockCategories } from "@/lib/mock-data";
+import { fetchData } from "@/lib/api";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { uploadFile } from "@/lib/upload";
@@ -126,6 +126,18 @@ export function TripForm({ trip, isAdmin = false }: TripFormProps) {
   const router = useRouter();
   const { cities } = useCity();
   const availableCities = cities.filter(c => c.name !== 'All Cities');
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [interests, setInterests] = useState<Interest[]>([]);
+
+  useEffect(() => {
+    fetchData<Category[]>('/api/admin/categories')
+      .then(setCategories)
+      .catch(() => setCategories([]));
+    fetchData<Interest[]>('/api/admin/interests')
+      .then(setInterests)
+      .catch(() => setInterests([]));
+  }, []);
   
   const [coverImageName, setCoverImageName] = useState<string | null>(null);
   const [galleryImageNames, setGalleryImageNames] = useState<string[]>([]);
@@ -276,7 +288,7 @@ export function TripForm({ trip, isAdmin = false }: TripFormProps) {
                         <FormField control={form.control} name="title" render={({ field }) => (<FormItem><FormLabel>Trip Title</FormLabel><FormControl><Input placeholder="e.g., Summer in Santorini" {...field} /></FormControl><FormMessage /></FormItem>)} />
                         <FormField control={form.control} name="location" render={({ field }) => (<FormItem><FormLabel>Display Location</FormLabel><FormControl><Input placeholder="e.g., Himalayas, India" {...field} /></FormControl><FormMessage /></FormItem>)} />
                         <FormField control={form.control} name="city" render={({ field }) => (<FormItem><FormLabel>Destination City</FormLabel><Select onValueChange={field.onChange} defaultValue={field.value}><FormControl><SelectTrigger><SelectValue placeholder="Select a destination city" /></SelectTrigger></FormControl><SelectContent>{availableCities.map(c => <SelectItem key={c.id} value={c.name}>{c.name}</SelectItem>)}</SelectContent></Select><FormMessage /></FormItem>)} />
-                        <FormField control={form.control} name="tripType" render={({ field }) => (<FormItem><FormLabel>Trip Category</FormLabel><Select onValueChange={field.onChange} defaultValue={field.value}><FormControl><SelectTrigger><SelectValue placeholder="Select a trip category" /></SelectTrigger></FormControl><SelectContent>{mockCategories.filter(c => c.status === 'Active').map(c => <SelectItem key={c.id} value={c.name}>{c.name}</SelectItem>)}</SelectContent></Select><FormMessage /></FormItem>)} />
+                        <FormField control={form.control} name="tripType" render={({ field }) => (<FormItem><FormLabel>Trip Category</FormLabel><Select onValueChange={field.onChange} defaultValue={field.value}><FormControl><SelectTrigger><SelectValue placeholder="Select a trip category" /></SelectTrigger></FormControl><SelectContent>{categories.filter(c => c.status === 'Active').map(c => <SelectItem key={c.id} value={c.name}>{c.name}</SelectItem>)}</SelectContent></Select><FormMessage /></FormItem>)} />
                         <FormField control={form.control} name="difficulty" render={({ field }) => (<FormItem><FormLabel>Difficulty Level</FormLabel><Select onValueChange={field.onChange} defaultValue={field.value}><FormControl><SelectTrigger><SelectValue placeholder="Select difficulty" /></SelectTrigger></FormControl><SelectContent><SelectItem value="Easy">Easy</SelectItem><SelectItem value="Moderate">Moderate</SelectItem><SelectItem value="Hard">Hard</SelectItem><SelectItem value="Challenging">Challenging</SelectItem></SelectContent></Select><FormMessage /></FormItem>)} />
                         <FormField control={form.control} name="duration" render={({ field }) => (<FormItem><FormLabel>Duration</FormLabel><FormControl><Input placeholder="e.g., 3 Days, 2 Nights" {...field} /></FormControl><FormMessage /></FormItem>)} />
                         <div className="grid grid-cols-2 gap-4">
@@ -293,7 +305,7 @@ export function TripForm({ trip, isAdmin = false }: TripFormProps) {
                                 <FormLabel>Interest Tags</FormLabel>
                                 <FormDescription>Select tags that best describe your trip. This helps users find your trip when they filter.</FormDescription>
                                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 pt-2">
-                                    {mockInterests.filter(i => i.status === 'Active').map((interest) => (
+                                    {interests.filter(i => i.status === 'Active').map((interest) => (
                                         <FormField
                                         key={interest.id}
                                         control={form.control}

--- a/src/context/CityContext.tsx
+++ b/src/context/CityContext.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import type { City } from '@/lib/types';
-import { cities as mockCities } from '@/lib/mock-data';
-import React, { createContext, useContext, useState, useMemo } from 'react';
+import { fetchData } from '@/lib/api';
+import React, { createContext, useContext, useState, useMemo, useEffect } from 'react';
 
 type CityContextType = {
   cities: City[];
@@ -15,8 +15,17 @@ const CityContext = createContext<CityContextType | undefined>(undefined);
 export const CityProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [selectedCity, setSelectedCity] = useState<string>('all');
   
-  // In a real app, this would be fetched from an API
-  const cities = useMemo(() => ([{ id: 'all', name: 'All Cities', enabled: true }, ...mockCities.filter(c => c.enabled)]), []);
+  const [cities, setCities] = useState<City[]>([]);
+
+  useEffect(() => {
+    fetchData<City[]>('/api/admin/cities')
+      .then(data => {
+        setCities([{ id: 'all', name: 'All Cities', enabled: true }, ...data.filter(c => c.enabled)]);
+      })
+      .catch(() => {
+        setCities([{ id: 'all', name: 'All Cities', enabled: true }]);
+      });
+  }, []);
 
   const value = useMemo(() => ({
     cities,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,9 @@
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+
+export async function fetchData<T>(endpoint: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BACKEND_URL}${endpoint}`, init);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${endpoint}`);
+  }
+  return res.json() as Promise<T>;
+}


### PR DESCRIPTION
## Summary
- introduce `fetchData` helper
- begin migrating City context and organizer pages to API data
- update Trip form to load categories and interests from API

## Testing
- `npm run typecheck` *(fails: Cannot find module errors)*
- `npm run build` *(fails: `next` not found)*
- `npm test` in `backend` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e88ab1b608328bc76a08f262d0836