### PR TITLE
Fix reCAPTCHA render on signup

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -69,6 +69,8 @@ export default function SignupPage() {
     if (typeof window === 'undefined') return;
     if (!recaptcha.current) {
       recaptcha.current = new RecaptchaVerifier(auth, 'signup-recaptcha', { size: 'invisible' });
+      // Render the reCAPTCHA widget so Firebase can send the OTP
+      void recaptcha.current.render();
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- call `recaptcha.render()` in signup page so OTPs can be sent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871fdc500748328a25dc25774858350