### PR TITLE
Improve signup feedback and OTP flow

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -206,6 +206,9 @@ A: The main application is a Next.js app (`localhost:3000`). The AI features are
 **Q: I get an error about a missing `GOOGLE_API_KEY`. What do I do?**
 A: You need to create a `.env` file in the project root and add your Google AI Studio API key to it, as described in Step 3.3.
 
+**Q: Firebase returns `auth/invalid-api-key` on the login page. What's wrong?**
+A: Your Firebase environment variables are missing or incorrect. Copy `.env.example` to `.env` and replace all `NEXT_PUBLIC_FIREBASE_*` placeholders with the values from your Firebase project. Restart the Next.js server after updating.
+
 **Q: Some images are placeholders. How do I change them?**
 A: The project uses `https://placehold.co` for mock images. In a production environment, you would integrate a file storage service (like Firebase Storage, AWS S3, or Cloudinary) for image uploads and replace the placeholder URLs with the URLs from your storage service.
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -35,7 +35,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { auth } from "@/lib/firebase";
-import { RecaptchaVerifier, signInWithPhoneNumber, ConfirmationResult, createUserWithEmailAndPassword } from "firebase/auth";
+import { RecaptchaVerifier, signInWithPhoneNumber, ConfirmationResult, createUserWithEmailAndPassword, signOut } from "firebase/auth";
 
 
 const SignupFormSchema = z.object({
@@ -69,6 +69,8 @@ export default function SignupPage() {
     if (typeof window === 'undefined') return;
     if (!recaptcha.current) {
       recaptcha.current = new RecaptchaVerifier(auth, 'signup-recaptcha', { size: 'invisible' });
+      // Render the reCAPTCHA widget so Firebase can send the OTP
+      void recaptcha.current.render();
     }
   }, []);
 
@@ -97,12 +99,6 @@ export default function SignupPage() {
     if (!response.ok) {
       throw new Error(result.message || 'Signup failed.');
     }
-
-    toast({
-      title: 'Account Created!',
-      description: 'Your account has been created successfully. Please log in to continue.',
-    });
-    router.push('/auth/login');
   };
 
   const handleSignup = async (data: SignupFormData) => {
@@ -117,6 +113,7 @@ export default function SignupPage() {
       if (signupMode === 'phone') {
         if (!confirmationResult) {
           const fullPhone = `${countryCode}${data.phone}`;
+          await recaptcha.current!.verify();
           const result = await signInWithPhoneNumber(auth, fullPhone, recaptcha.current!);
           setConfirmationResult(result);
           toast({ title: 'OTP Sent', description: `A verification code has been sent to ${fullPhone}.` });
@@ -127,6 +124,12 @@ export default function SignupPage() {
         }
         const cred = await confirmationResult.confirm(otp);
         await submitToBackend(cred.user.uid, data);
+        await signOut(auth);
+        toast({
+          title: 'Account Created!',
+          description: 'You can now log in with your phone number.',
+        });
+        setTimeout(() => router.push('/auth/login'), 500);
       } else {
         if (password.length < 6) {
           throw new Error('Password must be at least 6 characters.');
@@ -136,6 +139,12 @@ export default function SignupPage() {
         }
         const cred = await createUserWithEmailAndPassword(auth, data.email, password);
         await submitToBackend(cred.user.uid, data);
+        await signOut(auth);
+        toast({
+          title: 'Account Created!',
+          description: 'Please log in to continue.',
+        });
+        setTimeout(() => router.push('/auth/login'), 500);
       }
     } catch (error: any) {
       toast({

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -12,6 +12,12 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
+if (!firebaseConfig.apiKey) {
+  console.warn(
+    'Firebase config missing. Copy .env.example to .env and add your Firebase keys.'
+  );
+}
+
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);


### PR DESCRIPTION
## Summary
- sign out and show toast after user creation so success is visible
- verify reCAPTCHA before sending OTP so phone signup works
- warn if Firebase config keys are missing
- document how to fix `auth/invalid-api-key` errors

## Testing
- `npm test` in `backend/`


------
https://chatgpt.com/codex/tasks/task_e_6871fdc500748328a25dc25774858350