### PR TITLE
Move category API proxy to dedicated route

### DIFF
--- a/backend/src/models/Category.js
+++ b/backend/src/models/Category.js
@@ -1,7 +1,4 @@
 import mongoose from 'mongoose';
-import { NextRequest, NextResponse } from 'next/server';
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
 
 const categorySchema = new mongoose.Schema({
     name: String,
@@ -9,22 +6,3 @@ const categorySchema = new mongoose.Schema({
 });
 
 export default mongoose.model('Category', categorySchema);
-
-export async function GET() {
-    // Fetch categories from backend
-    const res = await fetch(`${BACKEND_URL}/api/categories`);
-    const data = await res.json();
-    return NextResponse.json(data, { status: res.status });
-}
-
-export async function POST(req: NextRequest) {
-    const body = await req.json();
-    // Create category in backend
-    const res = await fetch(`${BACKEND_URL}/api/categories`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-    });
-    const data = await res.json();
-    return NextResponse.json(data, { status: res.status });
-}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  try {
+    const backendUrl = `${process.env.BACKEND_URL || 'http://localhost:5000'}/api/categories`;
+    const url = new URL(backendUrl);
+    searchParams.forEach((value, key) => url.searchParams.append(key, value));
+    const res = await fetch(url.toString());
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error('Failed to fetch categories:', error);
+    return NextResponse.json({ message: 'An error occurred while fetching categories.' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const backendUrl = `${process.env.BACKEND_URL || 'http://localhost:5000'}/api/categories`;
+    const res = await fetch(backendUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error('Failed to create category:', error);
+    return NextResponse.json({ message: 'An error occurred while creating category.' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- clean up `Category` model file
- add category API proxy for Next.js in `src/app/api/categories`

## Testing
- `node --check backend/src/app.js`
- `npm run lint` *(fails: many lint errors)*
- `npm run typecheck` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878f093d988832883fa22c0225402d1