### PR TITLE
Add BACKEND_URL env docs

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -72,6 +72,15 @@ The application uses environment variables for configuration, particularly for t
 ### Step 3.4: Backend Environment Variables
 The Express backend in the `backend` folder uses its own `.env` file. Copy `backend/.env.example` to `backend/.env` and fill in your MongoDB URI, Firebase service account credentials, JWT secret, and Razorpay keys.
 
+### Step 3.5: Set `BACKEND_URL`
+The Next.js API routes in `src/app/api` proxy requests to your backend server. Specify its base URL in the same `.env` file created in Step&nbsp;3.3.
+
+```env
+BACKEND_URL=http://localhost:5000
+```
+
+Replace `http://localhost:5000` with the address of your deployed backend when running in production.
+
 ---
 
 ## 4. Running the Application Locally


### PR DESCRIPTION
## Summary
- explain BACKEND_URL usage in README2

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities, hooks rules, etc.)*
- `npm run typecheck` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878f0961d988328927380235013a388