### PR TITLE
Sanitize example env values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment variables for the Travonex frontend
+GOOGLE_API_KEY=your-google-api-key
+NEXT_PUBLIC_RAZORPAY_KEY_ID=your-razorpay-key-id
+CORS_ORIGIN=http://localhost:3000
+BACKEND_URL=http://localhost:5000
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+
+# Firebase client configuration
+NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id

--- a/README2.md
+++ b/README2.md
@@ -74,6 +74,8 @@ The application uses environment variables for configuration, particularly for t
 ### Step 3.4: Backend Environment Variables
 The Express backend in the `backend` folder uses its own `.env` file. Copy `backend/.env.example` to `.env` inside that folder and fill in your MongoDB URI, Firebase service account credentials, JWT secret, and Razorpay keys.
 
+> **Note**: The `.env.example` files in this repository contain dummy values. Copy them to `.env` and replace each placeholder with your real credentials before running the project.
+
 ### Step 3.5: Set `BACKEND_URL`
 The Next.js API routes in `src/app/api` proxy requests to your backend server. Specify its base URL in the same `.env` file created in Step&nbsp;3.3.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,10 @@
 # MongoDB connection string
-MONGODB_URI=mongodb://localhost:27017/travonex
+MONGODB_URI=mongodb://YOUR_MONGO_USER:YOUR_MONGO_PASS@localhost:27017/YOUR_DB
 
 # Firebase service account credentials
-FIREBASE_PROJECT_ID=your-project-id
-FIREBASE_CLIENT_EMAIL=your-client-email
-FIREBASE_PRIVATE_KEY=your-private-key
+FIREBASE_PROJECT_ID=firebase-demo-project
+FIREBASE_CLIENT_EMAIL=service-account@example.com
+FIREBASE_PRIVATE_KEY=fake-private-key
 
 # JWT secret for login route
 JWT_SECRET=changeme


### PR DESCRIPTION
## Summary
- add a root `.env.example` with clearly fake values
- update `backend/.env.example` placeholders
- mention placeholder env files in README2

## Testing
- `npm test`
- `cd backend && npm test` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879bff02d588328981023a1645d22f8