### PR TITLE
Update root tests script

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -200,7 +200,19 @@ The frontend is built to call these (or similar) API endpoints. You will find `/
 
 ---
 
-## 7. Frequently Asked Questions (FAQs)
+## 7. Running Tests
+
+Use the root `test` script to run the backend test suite:
+
+```bash
+npm test
+```
+
+This command runs `npm --prefix backend test`, executing the tests located in the `backend` directory.
+
+---
+
+## 8. Frequently Asked Questions (FAQs)
 
 **Q: Why do I need to run two servers?**
 A: The main application is a Next.js app (`localhost:3000`). The AI features are powered by Google's Genkit, which runs as a separate local server (`localhost:4000`). The Next.js app makes API calls to the Genkit server for things like destination suggestions.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "echo \"No tests configured\"",
+    "test": "npm --prefix backend test",
     "typecheck": "tsc --noEmit",
     "postinstall": "patch-package"
   },


### PR DESCRIPTION
## Summary
- run backend tests from the root `test` script
- explain test command in README2

## Testing
- `npm test` *(fails: missing `libcrypto.so.1.1`)*

------
https://chatgpt.com/codex/tasks/task_e_6879bff0f6c48328a6d87dbda34e031a