### PR TITLE
Add host network config to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "runArgs": ["--network=host"]
+}


### PR DESCRIPTION
## Summary
- configure devcontainer to use host network so apt works

## Testing
- `npm --prefix backend install`
- `npm test` *(fails: MongooseError: Can't call `openUri()` on an active connection)*

------
https://chatgpt.com/codex/tasks/task_e_6879c3eeb89883288442e0f93463b3d1