### PR TITLE
Implement admin revenue API and connect frontend

### DIFF
--- a/src/app/api/admin/revenue/route.ts
+++ b/src/app/api/admin/revenue/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const auth = request.headers.get('Authorization') || '';
+  try {
+    const backendUrl = `${process.env.BACKEND_URL || 'http://localhost:5000'}/api/admin/revenue`;
+    const res = await fetch(backendUrl, { headers: { Authorization: auth } });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error('Failed to fetch admin revenue:', error);
+    return NextResponse.json({ message: 'An error occurred.' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add backend endpoint `/api/admin/revenue`
- expose Next.js route to call the backend
- load revenue data dynamically in Admin Revenue page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879dbaa3a8883288dfe7028d6661dd9