### PR TITLE
Fix recaptcha container reuse in OTP verification

### DIFF
--- a/src/utils/otp.ts
+++ b/src/utils/otp.ts
@@ -4,9 +4,13 @@ import { auth } from '@/firebase/client';
 let verifier: RecaptchaVerifier | null = null;
 
 export const startOtpVerification = async (phoneNumber: string): Promise<string> => {
-  if (!verifier) {
-    verifier = new RecaptchaVerifier(auth, 'recaptcha-container', { size: 'invisible' });
+  // Always recreate the verifier to avoid "reCAPTCHA client element has been removed" errors
+  try {
+    verifier?.clear();
+  } catch {
+    // ignore if clear fails
   }
+  verifier = new RecaptchaVerifier(auth, 'recaptcha-container', { size: 'invisible' });
   const result = await signInWithPhoneNumber(auth, phoneNumber, verifier);
   return result.verificationId;
 };


### PR DESCRIPTION
## Summary
- recreate the Firebase `RecaptchaVerifier` each time OTP is requested
- avoid the "reCAPTCHA client element has been removed" error

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_687a03522694832889a3897f3c82c605