### PR TITLE
Fix recaptcha container reuse in OTP verification

### DIFF
--- a/src/utils/otp.ts
+++ b/src/utils/otp.ts
@@ -4,9 +4,13 @@ import { auth } from '@/firebase/client';
 let verifier: RecaptchaVerifier | null = null;
 
 export const startOtpVerification = async (phoneNumber: string): Promise<string> => {
-  if (!verifier) {
-    verifier = new RecaptchaVerifier(auth, 'recaptcha-container', { size: 'invisible' });
+  // Always recreate the verifier to avoid "reCAPTCHA client element has been removed" errors
+  try {
+    verifier?.clear();
+  } catch {
+    // ignore if clear fails
   }
+  verifier = new RecaptchaVerifier(auth, 'recaptcha-container', { size: 'invisible' });
   const result = await signInWithPhoneNumber(auth, phoneNumber, verifier);
   return result.verificationId;
 };

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -4,6 +4,9 @@ export const saveUserRole = async (idToken: string, role: string, info: Record<s
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ idToken, role, ...info })
   });
-  if (!res.ok) throw new Error('Failed to save user');
-  return res.json();
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error((data as any).message || 'Failed to save user');
+  }
+  return data;
 };


### PR DESCRIPTION
## Summary
- recreate the Firebase `RecaptchaVerifier` each time OTP is requested
- surface backend error messages from the signup API

## Testing
- `npm --prefix backend install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a03522694832889a3897f3c82c605