### PR TITLE
Improve Swagger docs generation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,6 @@
                 "cors": "^2.8.5",
                 "dotenv": "^17.2.0",
                 "express": "^5.1.0",
-                "express-list-endpoints": "^6.0.0",
                 "firebase-admin": "^13.4.0",
                 "mongoose": "^8.16.3",
                 "multer": "^2.0.1",
@@ -2826,15 +2825,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/express-list-endpoints": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/express-list-endpoints/-/express-list-endpoints-6.0.0.tgz",
-            "integrity": "sha512-1I30bSVego+AU/eSsX/bV2xrOXW5tFhsuXZp7wZd9396bAAxH7KHaAwLXQYra0Aw33xA67HmNiceGf2SOvXaLg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/extend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,6 @@
         "nodemailer": "^7.0.5",
         "razorpay": "^2.9.6",
         "uuid": "^11.1.0",
-        "express-list-endpoints": "^6.0.0",
         "swagger-ui-express": "^5.0.1",
         "swagger-jsdoc": "^6.2.8",
         "zod": "^3.24.4"

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -25,6 +25,29 @@ import loginRouter from './routes/login.js';
 import paymentsRouter from './routes/payments.js';
 import otpSignupRouter from './routes/otpSignup.js';
 import adminRouter from './routes/admin.js';
+
+// Mapping of base paths to routers for Swagger docs
+export const routeMappings = [
+  ['/api/trips', tripsRouter],
+  ['/api/users', usersRouter],
+  ['/api/organizers', organizersRouter],
+  ['/api/bookings', bookingsRouter],
+  ['/api/coupons', couponsRouter],
+  ['/api/disputes', disputesRouter],
+  ['/api/admin/disputes', adminDisputesRouter],
+  ['/api/reviews', reviewsRouter],
+  ['/api/cities', citiesRouter],
+  ['/api/categories', categoriesRouter],
+  ['/api/interests', interestsRouter],
+  ['/api/auth', authRouter],
+  ['/api/upload', uploadRouter],
+  ['/api/payments', paymentsRouter],
+  ['/api/admin', adminRouter],
+  ['/api/protected', protectedRouter],
+  ['/api/auth/signup', signupRouter],
+  ['/api/auth/login', loginRouter],
+  ['/api/auth/otp-signup', otpSignupRouter]
+];
 import swaggerUi from 'swagger-ui-express';
 import generateSwaggerSpec from './swagger.js';
 
@@ -47,31 +70,15 @@ app.use(cors({
 app.use(express.json());
 
 // API routes
-app.use('/api/trips', tripsRouter);
-app.use('/api/users', usersRouter);
-app.use('/api/organizers', organizersRouter);
-app.use('/api/bookings', bookingsRouter);
-app.use('/api/coupons', couponsRouter);
-app.use('/api/disputes', disputesRouter);
-app.use('/api/admin/disputes', adminDisputesRouter);
-app.use('/api/reviews', reviewsRouter);
-app.use('/api/cities', citiesRouter);
-app.use('/api/categories', categoriesRouter);
-app.use('/api/interests', interestsRouter);
-app.use('/api/auth', authRouter);
-app.use('/api/upload', uploadRouter);
-app.use('/api/payments', paymentsRouter);
-app.use('/api/admin', adminRouter);
-app.use('/api/protected', protectedRouter); // Example: requires auth
-app.use('/api/auth/signup', signupRouter);
-app.use('/api/auth/login', loginRouter);
-app.use('/api/auth/otp-signup', otpSignupRouter);
+for (const [basePath, router] of routeMappings) {
+  app.use(basePath, router);
+}
 
 app.get('/', (req, res) => {
     res.send('Travonex Backend API');
 });
 
-const swaggerSpec = generateSwaggerSpec(app);
+const swaggerSpec = generateSwaggerSpec(app, routeMappings);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // 404 handler


### PR DESCRIPTION
## Summary
- replace express-list-endpoints with custom router parser
- simplify swagger.js and ensure route mappings are processed
- remove unused express-list-endpoints dependency

## Testing
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_687a4d9cfec08328a5c758c019ba7183