### PR TITLE
Improve Swagger docs

### DIFF
--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -2,9 +2,25 @@ import express from 'express';
 import User from '../models/User.js';
 import { requireJwt } from '../middlewares/jwtAuth.js';
 
+/**
+ * @swagger
+ * tags:
+ *   name: Users
+ *   description: User management
+ */
+
 const router = express.Router();
 
-// Get all users
+/**
+ * @swagger
+ * /api/users:
+ *   get:
+ *     summary: List users
+ *     tags: [Users]
+ *   post:
+ *     summary: Create user
+ *     tags: [Users]
+ */
 router.get('/', async (req, res) => {
     try {
         const users = await User.find();
@@ -25,7 +41,16 @@ router.post('/', async (req, res) => {
     }
 });
 
-// GET /api/users/me/profile
+/**
+ * @swagger
+ * /api/users/me/profile:
+ *   get:
+ *     summary: Get current user profile
+ *     tags: [Users]
+ *   put:
+ *     summary: Update current user profile
+ *     tags: [Users]
+ */
 router.get('/me/profile', requireJwt('user'), async (req, res) => {
     try {
         const user = await User.findById(req.user.id).select('-password');

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -23,7 +23,8 @@ export default function generateSwaggerSpec(app, mappings = []) {
         version: '1.0.0'
       }
     },
-    apis: ['src/routes/*.js']
+    // Resolve absolute path so docs work regardless of CWD
+    apis: [new URL('./routes/*.js', import.meta.url).pathname]
   };
 
   const spec = swaggerJsdoc(options);
@@ -76,6 +77,14 @@ export default function generateSwaggerSpec(app, mappings = []) {
       });
     });
   }
+
+  // Merge duplicate paths that may include trailing slashes
+  const deduped = {};
+  for (const [path, ops] of Object.entries(spec.paths)) {
+    const key = path !== '/' && path.endsWith('/') ? path.slice(0, -1) : path;
+    deduped[key] = { ...(deduped[key] || {}), ...ops };
+  }
+  spec.paths = deduped;
 
   return spec;
 }


### PR DESCRIPTION
## Summary
- refine swagger spec generator to resolve route paths
- de-duplicate trailing slash paths
- add Swagger annotations to user routes for richer API docs

## Testing
- `npm test`
- `NODE_ENV=test FIREBASE_PROJECT_ID=dummy FIREBASE_CLIENT_EMAIL=dummy@example.com FIREBASE_PRIVATE_KEY=dummy RAZORPAY_KEY_ID=dummy RAZORPAY_KEY_SECRET=dummy node -e "import app,{routeMappings} from './backend/src/app.js'; import gen from './backend/src/swagger.js'; const spec=gen(app, routeMappings); console.log('count',Object.keys(spec.paths).length);"`

------
https://chatgpt.com/codex/tasks/task_e_687a702cad188328be1ad6224d778b79