### PR TITLE
Connect frontend login route to backend

### DIFF
--- a/backend/tests/login.test.js
+++ b/backend/tests/login.test.js
@@ -1,0 +1,42 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app.js';
+import User from '../src/models/User.js';
+import assert from 'assert';
+
+let mongoServer;
+
+before(async () => {
+  await mongoose.disconnect();
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri, { dbName: 'travonex-test' });
+  process.env.JWT_SECRET = 'testsecret';
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Auth login', () => {
+  it('logs in a user with email and password', async () => {
+    await User.create({ name: 'U1', email: 'u1@example.com', password: 'pass', referralCode: 'r1' });
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'u1@example.com', password: 'pass' });
+    assert.equal(res.statusCode, 200);
+    assert(res.body.user);
+    assert(res.body.token);
+    assert(res.body.redirectPath);
+  });
+
+  it('returns 401 for invalid password', async () => {
+    await User.create({ name: 'U2', email: 'u2@example.com', password: 'pass', referralCode: 'r2' });
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'u2@example.com', password: 'wrong' });
+    assert.equal(res.statusCode, 401);
+  });
+});

--- a/src/api/auth/login/route.ts
+++ b/src/api/auth/login/route.ts
@@ -18,91 +18,36 @@
  * - 500 Internal Server Error
  */
 import { NextResponse } from 'next/server';
-import { adminUsers, users as mockUsers, organizers as mockOrganizers } from '@/lib/mock-data';
-import type { UserSession } from '@/lib/types';
 
 export async function POST(request: Request) {
   try {
-    const { email, password } = await request.json();
-
-    if (!email || !password) {
-      return NextResponse.json({ message: 'Email and password are required' }, { status: 400 });
-    }
-
-    let sessionData: UserSession | null = null;
-    let redirectPath = '/';
-
-    const admin = adminUsers.find(admin => admin.email === email);
-    if (admin) {
-      if (admin.status !== 'Active') {
-        return NextResponse.json({ message: `Admin account is ${admin.status}. Please contact support.` }, { status: 403 });
-      }
-      if (password !== 'password') {
-        return NextResponse.json({ message: 'Invalid password.' }, { status: 401 });
-      }
-      sessionData = {
-        id: admin.id,
-        name: admin.name,
-        email: admin.email,
-        role: admin.role,
-        avatar: `https://placehold.co/40x40.png?text=${admin.name.charAt(0)}`
-      };
-      redirectPath = '/admin/dashboard';
-    } else {
-      const organizer = mockOrganizers.find(o => o.email === email);
-      if (organizer && password === 'password') {
-        sessionData = {
-          id: organizer.id,
-          name: organizer.name,
-          email: organizer.email,
-          role: 'ORGANIZER',
-          avatar: `https://placehold.co/40x40.png?text=${organizer.name.charAt(0)}`
-        };
-        redirectPath = organizer.kycStatus === 'Verified' ? '/trip-organiser/dashboard' : '/trip-organiser/profile';
-      } else {
-        const regularUser = mockUsers.find(u => u.email === email);
-        if (regularUser && password === 'password') {
-          sessionData = {
-            id: regularUser.id,
-            name: regularUser.name,
-            email: regularUser.email,
-            role: 'USER',
-            avatar: regularUser.avatar
-          };
-          redirectPath = '/';
-        }
-      }
-    }
-    
-    if (sessionData) {
-      // Create a mock token for the session. In a real app, this would be a signed JWT.
-      const token = `${sessionData.id}-${sessionData.role.replace(/ /g, '_')}`;
-      
-      const response = NextResponse.json({ user: sessionData, token, redirectPath });
-
-      // Set a cookie for server-side component access
+    const body = await request.json();
+    const backendRes = await fetch(`${process.env.BACKEND_URL || 'http://localhost:5000'}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await backendRes.json();
+    const response = NextResponse.json(data, { status: backendRes.status });
+    if (backendRes.ok && data.user && data.token) {
       response.cookies.set({
-          name: 'userSession',
-          value: JSON.stringify(sessionData),
-          httpOnly: true, // Recommended for security
-          path: '/',
-          maxAge: 60 * 60 * 24 * 7 // 1 week
+        name: 'userSession',
+        value: JSON.stringify(data.user),
+        httpOnly: true,
+        path: '/',
+        maxAge: 60 * 60 * 24 * 7,
       });
       response.cookies.set({
-          name: 'authToken',
-          value: token,
-          httpOnly: true,
-          path: '/',
-          maxAge: 60 * 60 * 24 * 7 // 1 week
+        name: 'authToken',
+        value: data.token,
+        httpOnly: true,
+        path: '/',
+        maxAge: 60 * 60 * 24 * 7,
       });
-      
-      return response;
-    } else {
-      return NextResponse.json({ message: 'User or Organizer account not found.' }, { status: 404 });
     }
-
-  } catch (error) {
-    console.error('Login error:', error);
+    return response;
+  } catch (err) {
+    console.error('Login error:', err);
     return NextResponse.json({ message: 'An internal server error occurred' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- forward login requests from frontend API to backend
- add backend login tests for success and failure cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a9d8b91f88328be6b36ffb2bb67a3