### PR TITLE
Replace mock-data with API fetches

### DIFF
--- a/src/app/admin/admin-roles/page.tsx
+++ b/src/app/admin/admin-roles/page.tsx
@@ -33,7 +33,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { adminUsers, organizers as mockOrganizers } from "@/lib/mock-data";
+import { useEffect } from "react";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -89,13 +89,20 @@ type AdminUserFormData = z.infer<typeof AdminUserFormSchema>;
 export default function AdminRolesPage() {
     const { toast } = useToast();
     const [roles, setRoles] = React.useState<Role[]>(mockRoles);
-    const [admins, setAdmins] = React.useState<AdminUser[]>(adminUsers);
+    const [admins, setAdmins] = React.useState<AdminUser[]>([]);
     const [selectedRole, setSelectedRole] = React.useState<Role | null>(null);
     const [permissions, setPermissions] = React.useState<Record<string, string[]>>({});
     const [isRoleDialogOpen, setIsRoleDialogOpen] = React.useState(false);
     const [isAdminDialogOpen, setIsAdminDialogOpen] = React.useState(false);
     const [editingRole, setEditingRole] = React.useState<Role | null>(null);
     const [isSaving, setIsSaving] = React.useState(false);
+
+    useEffect(() => {
+        fetch('/api/admin/users?role=admin')
+            .then(res => res.json())
+            .then(setAdmins)
+            .catch(() => setAdmins([]));
+    }, []);
 
     const roleForm = useForm<RoleFormData>({
         resolver: zodResolver(RoleFormSchema),

--- a/src/app/admin/audit-log/page.tsx
+++ b/src/app/admin/audit-log/page.tsx
@@ -22,7 +22,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Download, SlidersHorizontal } from "lucide-react";
-import { auditLogs as mockAuditLogs } from "@/lib/mock-data";
+import { useEffect } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
@@ -33,6 +33,14 @@ import { ClientOnlyDate } from "@/components/common/ClientOnlyDate";
 
 export default function AdminAuditLogPage() {
     const [dateRange, setDateRange] = React.useState<{from?: Date, to?: Date}>({});
+    const [auditLogs, setAuditLogs] = React.useState<any[]>([]);
+
+    useEffect(() => {
+        fetch('/api/admin/audit-logs')
+            .then(res => res.json())
+            .then(setAuditLogs)
+            .catch(() => setAuditLogs([]));
+    }, []);
 
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
@@ -97,7 +105,7 @@ export default function AdminAuditLogPage() {
                     </TableRow>
                 </TableHeader>
                 <TableBody>
-                    {mockAuditLogs.map(log => (
+                    {auditLogs.map(log => (
                         <TableRow key={log.id}>
                             <TableCell>{log.adminName} ({log.adminId})</TableCell>
                             <TableCell><Badge variant="secondary">{log.action}</Badge></TableCell>

--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -32,7 +32,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { bookings as mockBookings, trips, users } from "@/lib/mock-data";
+import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 import type { Booking, Trip } from "@/lib/types";
 import { Users } from "lucide-react";
@@ -160,7 +160,14 @@ function BookingDetailsDialog({ booking, trip }: { booking: Booking; trip: Trip 
 
 
 export default function AdminBookingsPage() {
-  const [bookings, setBookings] = React.useState<Booking[]>(mockBookings);
+  const [bookings, setBookings] = React.useState<Booking[]>([]);
+
+  useEffect(() => {
+    fetch('/api/admin/bookings')
+      .then(res => res.json())
+      .then(setBookings)
+      .catch(() => setBookings([]));
+  }, []);
   
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
@@ -192,9 +199,9 @@ export default function AdminBookingsPage() {
             </TableHeader>
             <TableBody>
               {bookings.length > 0 ? bookings.map((booking) => {
-                const trip = trips.find(t => t.id === booking.tripId);
-                const user = users.find(u => u.id === booking.userId);
-                const batch = trip?.batches.find(b => b.id === booking.batchId);
+                const trip = (booking as any).trip;
+                const user = (booking as any).user;
+                const batch = trip?.batches?.find((b: any) => b.id === booking.batchId);
                 
                 return (
                     <TableRow key={booking.id}>

--- a/src/app/admin/cities/page.tsx
+++ b/src/app/admin/cities/page.tsx
@@ -18,15 +18,22 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { cities as mockCities } from "@/lib/mock-data";
+import { useEffect } from "react";
 import { Switch } from "@/components/ui/switch";
 import { PlusCircle } from "lucide-react";
 import type { City } from "@/lib/types";
 import { useToast } from "@/hooks/use-toast";
 
 export default function AdminCitiesPage() {
-  const [cities, setCities] = React.useState<City[]>(mockCities);
+  const [cities, setCities] = React.useState<City[]>([]);
   const { toast } = useToast();
+
+  useEffect(() => {
+    fetch('/api/admin/cities')
+      .then(res => res.json())
+      .then(setCities)
+      .catch(() => setCities([]));
+  }, []);
 
   const handleStatusToggle = (id: string, newStatus: boolean) => {
     // BACKEND: Call PUT /api/admin/cities/{id} with { enabled: newStatus }

--- a/src/app/admin/disputes/page.tsx
+++ b/src/app/admin/disputes/page.tsx
@@ -32,7 +32,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { disputes as mockDisputes, users, organizers, bookings } from "@/lib/mock-data";
+import { useEffect } from "react";
 import type { Dispute } from "@/lib/types";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
@@ -42,9 +42,9 @@ import { Textarea } from "@/components/ui/textarea";
 function DisputeDetailsDialog({ dispute, isOpen, onOpenChange }: { dispute: Dispute | null, isOpen: boolean, onOpenChange: (open: boolean) => void }) {
     if (!dispute) return null;
 
-    const user = users.find(u => u.id === dispute.userId);
-    const organizer = organizers.find(o => o.id === dispute.organizerId);
-    const booking = bookings.find(b => b.id === dispute.bookingId);
+    const user = (dispute as any).user;
+    const organizer = (dispute as any).organizer;
+    const booking = (dispute as any).booking;
 
     return (
         <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -91,8 +91,16 @@ function DisputeDetailsDialog({ dispute, isOpen, onOpenChange }: { dispute: Disp
 
 
 export default function AdminDisputesPage() {
+  const [disputes, setDisputes] = React.useState<Dispute[]>([]);
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
   const [selectedDispute, setSelectedDispute] = React.useState<Dispute | null>(null);
+
+  useEffect(() => {
+    fetch('/api/admin/disputes')
+      .then(res => res.json())
+      .then(setDisputes)
+      .catch(() => setDisputes([]));
+  }, []);
 
   const handleViewDetails = (dispute: Dispute) => {
     setSelectedDispute(dispute);
@@ -129,9 +137,9 @@ export default function AdminDisputesPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {mockDisputes.map((dispute) => {
-                  const user = users.find(u => u.id === dispute.userId);
-                  const organizer = organizers.find(o => o.id === dispute.organizerId);
+              {disputes.map((dispute) => {
+                  const user = (dispute as any).user;
+                  const organizer = (dispute as any).organizer;
                   return (
                       <TableRow key={dispute.id}>
                           <TableCell className="font-mono">{dispute.bookingId}</TableCell>

--- a/src/app/admin/notifications/page.tsx
+++ b/src/app/admin/notifications/page.tsx
@@ -19,14 +19,21 @@ import * as React from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { adminNotifications as mockNotifications } from "@/lib/mock-data";
+import { useEffect } from "react";
 import { CheckCircle, Eye } from "lucide-react";
 import Link from "next/link";
 import { ClientOnlyDate } from "@/components/common/ClientOnlyDate";
 
 
 export default function AdminNotificationsPage() {
-    const [notifications, setNotifications] = React.useState(mockNotifications);
+    const [notifications, setNotifications] = React.useState<any[]>([]);
+
+    useEffect(() => {
+        fetch('/api/admin/notifications')
+            .then(res => res.json())
+            .then(setNotifications)
+            .catch(() => setNotifications([]));
+    }, []);
 
     const unreadNotifications = notifications.filter(n => !n.isRead);
     const allNotifications = notifications;

--- a/src/app/admin/payouts/page.tsx
+++ b/src/app/admin/payouts/page.tsx
@@ -43,7 +43,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { payouts as mockPayouts, organizers, trips } from "@/lib/mock-data";
+import { useEffect } from "react";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
@@ -83,7 +83,7 @@ function ProcessPayoutDialog({ payout, onPayoutProcessed }: { payout: Payout, on
         setOpen(false); // Close the dialog
     };
 
-    const organizer = organizers.find(o => o.id === payout.organizerId);
+    const organizer = (payout as any).organizer;
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>
@@ -141,9 +141,9 @@ function PayoutDetailsDialog({ payout }: { payout: Payout }) {
     
     // DEV_COMMENT: Fetch related data to display in the dialog.
     // In a real app, this data might be passed in directly or fetched via a dedicated API endpoint.
-    const organizer = organizers.find(o => o.id === payout.organizerId);
-    const trip = trips.find(t => t.id === payout.tripId);
-    const batch = trip?.batches.find(b => b.id === payout.batchId);
+    const organizer = (payout as any).organizer;
+    const trip = (payout as any).trip;
+    const batch = trip?.batches?.find((b: any) => b.id === payout.batchId);
     
     const commissionPercentage = payout.totalRevenue > 0 ? ((payout.platformCommission / payout.totalRevenue) * 100).toFixed(1) : 0;
 
@@ -232,8 +232,14 @@ function PayoutDetailsDialog({ payout }: { payout: Payout }) {
 
 
 export default function AdminPayoutsPage() {
-    // In a real app, this state would be managed via API calls and a data fetching library.
-    const [payouts, setPayouts] = React.useState<Payout[]>(mockPayouts);
+    const [payouts, setPayouts] = React.useState<Payout[]>([]);
+
+    useEffect(() => {
+        fetch('/api/admin/payouts')
+            .then(res => res.json())
+            .then(setPayouts)
+            .catch(() => setPayouts([]));
+    }, []);
 
     const handlePayoutProcessed = (payoutId: string, details: any) => {
         // This simulates the state update after a successful API call.
@@ -279,9 +285,9 @@ export default function AdminPayoutsPage() {
                         </TableHeader>
                         <TableBody>
                             {payouts.map((payout) => {
-                                const organizer = organizers.find(o => o.id === payout.organizerId);
-                                const trip = trips.find(t => t.id === payout.tripId);
-                                const batch = trip?.batches.find(b => b.id === payout.batchId);
+                                const organizer = (payout as any).organizer;
+                                const trip = (payout as any).trip;
+                                const batch = trip?.batches?.find((b: any) => b.id === payout.batchId);
                                 return (
                                     <TableRow key={payout.id}>
                                         <TableCell className="font-medium">{organizer?.name || 'N/A'}</TableCell>

--- a/src/app/admin/promotions/page.tsx
+++ b/src/app/admin/promotions/page.tsx
@@ -25,7 +25,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { PlusCircle, Edit, Loader2 } from "lucide-react";
-import { promoCodes as mockPromoCodes } from "@/lib/mock-data";
+import { useEffect } from "react";
 import type { PromoCode } from "@/lib/types";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
@@ -84,14 +84,19 @@ export default function AdminPromotionsPage() {
     resolver: zodResolver(PromoCodeFormSchema),
   });
 
-  React.useEffect(() => {
-    // FRONTEND: Simulate API call
+  useEffect(() => {
     setIsLoading(true);
-    setTimeout(() => {
-        setPromoCodes(mockPromoCodes);
+    fetch('/api/admin/promotions')
+      .then(res => res.json())
+      .then((data) => {
+        setPromoCodes(data);
         setIsLoading(false);
-    }, 1000);
-  }, [])
+      })
+      .catch(() => {
+        setPromoCodes([]);
+        setIsLoading(false);
+      });
+  }, []);
 
   const handleAddNew = () => {
     setEditingPromo(null);

--- a/src/app/admin/refunds/page.tsx
+++ b/src/app/admin/refunds/page.tsx
@@ -35,7 +35,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { bookings as mockBookings, trips, users } from "@/lib/mock-data";
+import { useEffect } from "react";
 import type { Booking } from "@/lib/types";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
@@ -106,8 +106,14 @@ function ProcessRefundDialog({ booking, onRefundProcessed }: { booking: Booking,
 }
 
 export default function AdminRefundsPage() {
-  // BACKEND: Fetch from `GET /api/admin/refunds` or `GET /api/bookings?status=Cancelled`
-  const [bookings, setBookings] = React.useState<Booking[]>(mockBookings.filter(b => b.status === 'Cancelled'));
+  const [bookings, setBookings] = React.useState<Booking[]>([]);
+
+  useEffect(() => {
+    fetch('/api/admin/refunds')
+      .then(res => res.json())
+      .then(setBookings)
+      .catch(() => setBookings([]));
+  }, []);
   
   const handleRefundProcessed = (bookingId: string) => {
     setBookings(currentBookings => 
@@ -148,7 +154,7 @@ export default function AdminRefundsPage() {
             </TableHeader>
             <TableBody>
               {pendingRefunds.length > 0 ? pendingRefunds.map((booking) => {
-                const user = users.find(u => u.id === booking.userId);
+                const user = (booking as any).user;
                 
                 return (
                     <TableRow key={booking.id}>

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -27,7 +27,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { DatePicker } from "@/components/ui/datepicker";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { organizers, cities } from "@/lib/mock-data";
+import { useEffect } from "react";
 
 
 const monthlyChartData = [
@@ -57,15 +57,34 @@ const categoryChartConfig = {
     bookings: { label: "Bookings", color: "hsl(var(--primary))" },
 } satisfies ChartConfig;
 
-// DEV_COMMENT: Mock values for display. In a real app, these would come from the API.
-const mockTotalRevenue = 1234567;
-const mockTotalBookings = 1234;
-const mockNewUsers = 573;
-const mockAvgBookingValue = 2450;
+interface Summary {
+  totalRevenue: number;
+  totalBookings: number;
+  newUsers: number;
+  avgBookingValue: number;
+}
 
 
 export default function AdminReportsPage() {
   const [dateRange, setDateRange] = React.useState<{from?: Date, to?: Date}>({});
+  const [organizers, setOrganizers] = React.useState<any[]>([]);
+  const [summary, setSummary] = React.useState<Summary>({
+    totalRevenue: 0,
+    totalBookings: 0,
+    newUsers: 0,
+    avgBookingValue: 0,
+  });
+
+  useEffect(() => {
+    fetch('/api/admin/organizers')
+      .then(res => res.json())
+      .then(setOrganizers)
+      .catch(() => setOrganizers([]));
+    fetch('/api/admin/reports/summary')
+      .then(res => res.json())
+      .then(setSummary)
+      .catch(() => setSummary({ totalRevenue: 0, totalBookings: 0, newUsers: 0, avgBookingValue: 0 }));
+  }, []);
 
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
@@ -108,7 +127,7 @@ export default function AdminReportsPage() {
             <span className="text-muted-foreground">₹</span>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">₹{mockTotalRevenue.toLocaleString('en-IN')}</div>
+            <div className="text-2xl font-bold">₹{summary.totalRevenue.toLocaleString('en-IN')}</div>
             <p className="text-xs text-muted-foreground">in selected period</p>
           </CardContent>
         </Card>
@@ -118,7 +137,7 @@ export default function AdminReportsPage() {
             <Briefcase className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">+{mockTotalBookings.toLocaleString('en-IN')}</div>
+            <div className="text-2xl font-bold">+{summary.totalBookings.toLocaleString('en-IN')}</div>
             <p className="text-xs text-muted-foreground">+12.1% from last period</p>
           </CardContent>
         </Card>
@@ -128,7 +147,7 @@ export default function AdminReportsPage() {
             <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">+{mockNewUsers.toLocaleString('en-IN')}</div>
+            <div className="text-2xl font-bold">+{summary.newUsers.toLocaleString('en-IN')}</div>
             <p className="text-xs text-muted-foreground">in selected period</p>
           </CardContent>
         </Card>
@@ -138,7 +157,7 @@ export default function AdminReportsPage() {
             <BarChart2 className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">₹{mockAvgBookingValue.toLocaleString('en-IN')}</div>
+            <div className="text-2xl font-bold">₹{summary.avgBookingValue.toLocaleString('en-IN')}</div>
             <p className="text-xs text-muted-foreground">per traveler</p>
           </CardContent>
         </Card>

--- a/src/app/admin/roles/page.tsx
+++ b/src/app/admin/roles/page.tsx
@@ -33,7 +33,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { adminUsers, organizers as mockOrganizers } from "@/lib/mock-data";
+import { useEffect } from "react";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -89,13 +89,20 @@ type AdminUserFormData = z.infer<typeof AdminUserFormSchema>;
 export default function AdminRolesPage() {
     const { toast } = useToast();
     const [roles, setRoles] = React.useState<Role[]>(mockRoles);
-    const [admins, setAdmins] = React.useState<AdminUser[]>(adminUsers);
+    const [admins, setAdmins] = React.useState<AdminUser[]>([]);
     const [selectedRole, setSelectedRole] = React.useState<Role | null>(null);
     const [permissions, setPermissions] = React.useState<Record<string, string[]>>({});
     const [isRoleDialogOpen, setIsRoleDialogOpen] = React.useState(false);
     const [isAdminDialogOpen, setIsAdminDialogOpen] = React.useState(false);
     const [editingRole, setEditingRole] = React.useState<Role | null>(null);
     const [isSaving, setIsSaving] = React.useState(false);
+
+    useEffect(() => {
+        fetch('/api/admin/users?role=admin')
+            .then(res => res.json())
+            .then(setAdmins)
+            .catch(() => setAdmins([]));
+    }, []);
 
     const roleForm = useForm<RoleFormData>({
         resolver: zodResolver(RoleFormSchema),

--- a/src/app/admin/trip-organisers/page.tsx
+++ b/src/app/admin/trip-organisers/page.tsx
@@ -32,12 +32,19 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { organizers as mockOrganizers } from "@/lib/mock-data";
+import { useEffect } from "react";
 import type { Organizer } from "@/lib/types";
 import { Eye } from "lucide-react";
 
 export default function AdminTripOrganisersPage() {
-  const [organizers, setOrganizers] = React.useState<Organizer[]>(mockOrganizers);
+  const [organizers, setOrganizers] = React.useState<Organizer[]>([]);
+
+  useEffect(() => {
+    fetch('/api/admin/organizers')
+      .then(res => res.json())
+      .then(setOrganizers)
+      .catch(() => setOrganizers([]));
+  }, []);
 
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">

--- a/src/app/admin/trips/[tripId]/edit/page.tsx
+++ b/src/app/admin/trips/[tripId]/edit/page.tsx
@@ -12,18 +12,17 @@
  * - **Audit Trail**: The backend should log that the change was made by an admin, including the admin's ID and the provided remark, in the `tripChangeLogs`.
  */
 import { TripForm } from "@/components/trips/TripForm";
-import { trips } from "@/lib/mock-data";
 import { notFound } from "next/navigation";
 
 // Disable static generation to avoid type mismatch for params during build
 export const dynamic = "force-dynamic";
 
-export default function AdminEditTripPage({ params }: { params: { tripId: string } }) {
-    // BACKEND: Fetch trip data using a secure admin endpoint
-    const trip = trips.find(t => t.id === params.tripId);
-    if (!trip) {
+export default async function AdminEditTripPage({ params }: { params: { tripId: string } }) {
+    const res = await fetch(`/api/admin/trips/${params.tripId}`);
+    if (!res.ok) {
         notFound();
     }
+    const trip = await res.json();
   
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">

--- a/src/app/admin/trips/page.tsx
+++ b/src/app/admin/trips/page.tsx
@@ -17,7 +17,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { trips as mockTrips, organizers } from "@/lib/mock-data";
+import { useEffect } from "react";
 import type { Trip } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -40,8 +40,20 @@ const getStatusBadgeClass = (status: Trip['status']) => {
 }
 
 export default function AdminTripsListPage() {
-  const [trips, setTrips] = useState<Trip[]>(mockTrips);
+  const [trips, setTrips] = useState<Trip[]>([]);
+  const [organizers, setOrganizers] = useState<any[]>([]);
   const { toast } = useToast();
+
+  useEffect(() => {
+    fetch('/api/admin/trips')
+      .then(res => res.json())
+      .then(setTrips)
+      .catch(() => setTrips([]));
+    fetch('/api/admin/organizers')
+      .then(res => res.json())
+      .then(setOrganizers)
+      .catch(() => setOrganizers([]));
+  }, []);
 
   const handleStatusChange = (tripId: string, newStatus: Trip['status']) => {
     // DEV_COMMENT: Simulates an API call to update the trip's status.


### PR DESCRIPTION
## Summary
- swap out mock data imports for API calls across admin pages
- populate page state from backend endpoints via `fetch`
- clean up leftover mock data comments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a9d9833808328b1a26fb073b9ff50