### PR TITLE
Implement wallet transactions API

### DIFF
--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -61,6 +61,17 @@ router.get('/me/profile', requireJwt('user'), async (req, res) => {
     }
 });
 
+// GET /api/users/me/wallet-transactions
+router.get('/me/wallet-transactions', requireJwt('user'), async (req, res) => {
+    try {
+        const user = await User.findById(req.user.id).select('walletTransactions');
+        if (!user) return res.status(404).json({ message: 'User not found' });
+        res.json(user.walletTransactions || []);
+    } catch (err) {
+        res.status(500).json({ message: 'Failed to fetch wallet transactions', details: err.message });
+    }
+});
+
 // PUT /api/users/me/profile
 router.put('/me/profile', requireJwt('user'), async (req, res) => {
     try {

--- a/backend/tests/userWalletTransactions.test.js
+++ b/backend/tests/userWalletTransactions.test.js
@@ -1,0 +1,40 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app.js';
+import User from '../src/models/User.js';
+import jwt from 'jsonwebtoken';
+import assert from 'assert';
+
+let mongoServer;
+let token;
+
+before(async () => {
+  await mongoose.disconnect();
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri, { dbName: 'travonex-test' });
+  process.env.JWT_SECRET = 'testsecret';
+  const transactions = [
+    { date: new Date(), description: 'Referral Bonus', amount: 100, type: 'Credit', source: 'Referral' },
+    { date: new Date(), description: 'Booking Payment', amount: -50, type: 'Debit', source: 'Booking' }
+  ];
+  const user = await User.create({ name: 'U', email: 'wallet@example.com', password: 'p', referralCode: 'ref123', walletTransactions: transactions });
+  token = jwt.sign({ id: user._id.toString(), role: 'user' }, process.env.JWT_SECRET);
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Wallet transactions API', () => {
+  it('returns wallet transactions for authenticated user', async () => {
+    const res = await request(app)
+      .get('/api/users/me/wallet-transactions')
+      .set('Authorization', `Bearer ${token}`);
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.length, 2);
+    assert.equal(res.body[0].description, 'Referral Bonus');
+  });
+});


### PR DESCRIPTION
## Summary
- add GET /api/users/me/wallet-transactions route
- load wallet transactions on profile page when wallet tab opens
- show real wallet transaction history
- test wallet transactions route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a9d9f875c8328af3ac8d7065f3079