### PR TITLE
Add query filter to trips route

### DIFF
--- a/backend/src/routes/trips.js
+++ b/backend/src/routes/trips.js
@@ -29,7 +29,17 @@ const router = express.Router();
 // Get all trips
 router.get('/', async (req, res) => {
     try {
-        const trips = await Trip.find().populate('organizer');
+        const query = {};
+        if (req.query.isBanner === 'true') {
+            query.isBannerTrip = true;
+        }
+
+        let tripQuery = Trip.find(query).populate('organizer');
+        if (req.query.limit && !isNaN(parseInt(req.query.limit))) {
+            tripQuery = tripQuery.limit(parseInt(req.query.limit, 10));
+        }
+
+        const trips = await tripQuery;
         res.json(trips);
     } catch (err) {
         res.status(500).json({ error: err.message });

--- a/backend/tests/tripsQuery.test.js
+++ b/backend/tests/tripsQuery.test.js
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app.js';
+import Trip from '../src/models/Trip.js';
+import assert from 'assert';
+
+let mongoServer;
+
+before(async () => {
+  await mongoose.disconnect();
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri, { dbName: 'travonex-test' });
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Trips query parameters', () => {
+  beforeEach(async () => {
+    await Trip.deleteMany({});
+  });
+
+  it('filters banner trips when isBanner=true', async () => {
+    await Trip.create([
+      { title: 'B1', slug: 'b1', isBannerTrip: true },
+      { title: 'N1', slug: 'n1', isBannerTrip: false },
+      { title: 'B2', slug: 'b2', isBannerTrip: true }
+    ]);
+
+    const res = await request(app).get('/api/trips?isBanner=true');
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.length, 2);
+    assert(res.body.every(t => t.isBannerTrip === true));
+  });
+
+  it('applies numeric limit', async () => {
+    await Trip.create([
+      { title: 'T1', slug: 't1' },
+      { title: 'T2', slug: 't2' },
+      { title: 'T3', slug: 't3' }
+    ]);
+
+    const res = await request(app).get('/api/trips?limit=2');
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.length, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- filter `/api/trips` by `isBanner` query param
- support numeric `limit` query param
- test banner filtering and limit behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b0a4115288328b30c2e14438cd326