### PR TITLE
Add banners API route

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -19,6 +19,7 @@ import reviewsRouter from './routes/reviews.js';
 import couponsRouter from './routes/coupons.js';
 import disputesRouter from './routes/disputes.js';
 import adminDisputesRouter from './routes/adminDisputes.js';
+import bannersRouter from './routes/banners.js';
 import protectedRouter from './routes/protected.js';
 import signupRouter from './routes/signup.js';
 import loginRouter from './routes/login.js';
@@ -39,6 +40,7 @@ export const routeMappings = [
   ['/api/cities', citiesRouter],
   ['/api/categories', categoriesRouter],
   ['/api/interests', interestsRouter],
+  ['/api/banners', bannersRouter],
   ['/api/auth', authRouter],
   ['/api/upload', uploadRouter],
   ['/api/payments', paymentsRouter],

--- a/backend/src/routes/banners.js
+++ b/backend/src/routes/banners.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import Banner from '../models/Banner.js';
+
+const router = express.Router();
+
+// GET /api/banners - list active banners
+router.get('/', async (req, res) => {
+  try {
+    const banners = await Banner.find({ isActive: true });
+    res.json(banners);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/backend/tests/banners.test.js
+++ b/backend/tests/banners.test.js
@@ -1,0 +1,33 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app.js';
+import Banner from '../src/models/Banner.js';
+import assert from 'assert';
+
+let mongoServer;
+
+before(async () => {
+  await mongoose.disconnect();
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri, { dbName: 'travonex-test' });
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Banners API', () => {
+  it('returns only active banners', async () => {
+    await Banner.create([
+      { title: 'Active Banner', imageUrl: 'http://img', isActive: true },
+      { title: 'Inactive Banner', imageUrl: 'http://img2', isActive: false }
+    ]);
+    const res = await request(app).get('/api/banners');
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.length, 1);
+    assert.equal(res.body[0].title, 'Active Banner');
+  });
+});


### PR DESCRIPTION
## Summary
- add banners route to return active banners
- wire up banners router in main app
- test banners API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b0a44b46083288b8d091ad21967d8