### PR TITLE
Add CMS content and FAQ endpoints

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -25,6 +25,8 @@ import loginRouter from './routes/login.js';
 import paymentsRouter from './routes/payments.js';
 import otpSignupRouter from './routes/otpSignup.js';
 import adminRouter from './routes/admin.js';
+import contentRouter from './routes/content.js';
+import faqsRouter from './routes/faqs.js';
 
 // Mapping of base paths to routers for Swagger docs
 export const routeMappings = [
@@ -46,7 +48,9 @@ export const routeMappings = [
   ['/api/protected', protectedRouter],
   ['/api/auth/signup', signupRouter],
   ['/api/auth/login', loginRouter],
-  ['/api/auth/otp-signup', otpSignupRouter]
+  ['/api/auth/otp-signup', otpSignupRouter],
+  ['/api/content', contentRouter],
+  ['/api/faqs', faqsRouter]
 ];
 import swaggerUi from 'swagger-ui-express';
 import generateSwaggerSpec from './swagger.js';

--- a/backend/src/models/Content.js
+++ b/backend/src/models/Content.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+const contentSchema = new mongoose.Schema({
+  slug: { type: String, required: true, unique: true },
+  body: { type: String, default: '' },
+}, { timestamps: true });
+
+export default mongoose.model('Content', contentSchema);

--- a/backend/src/models/Faq.js
+++ b/backend/src/models/Faq.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+const faqSchema = new mongoose.Schema({
+  question: { type: String, required: true },
+  answer: { type: String, required: true },
+}, { timestamps: true });
+
+export default mongoose.model('Faq', faqSchema);

--- a/backend/src/routes/content.js
+++ b/backend/src/routes/content.js
@@ -1,0 +1,31 @@
+import express from 'express';
+import Content from '../models/Content.js';
+
+const router = express.Router();
+
+// GET /api/content/:slug
+router.get('/:slug', async (req, res) => {
+  try {
+    const content = await Content.findOne({ slug: req.params.slug });
+    if (!content) return res.status(404).json({ error: 'Not found' });
+    res.json(content);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// PUT /api/content/:slug
+router.put('/:slug', async (req, res) => {
+  try {
+    const content = await Content.findOneAndUpdate(
+      { slug: req.params.slug },
+      { body: req.body.body },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+    res.json(content);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/backend/src/routes/faqs.js
+++ b/backend/src/routes/faqs.js
@@ -1,0 +1,52 @@
+import express from 'express';
+import Faq from '../models/Faq.js';
+
+const router = express.Router();
+
+// GET /api/faqs
+router.get('/', async (req, res) => {
+  try {
+    const faqs = await Faq.find();
+    res.json(faqs);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/faqs
+router.post('/', async (req, res) => {
+  try {
+    const faq = await Faq.create({ question: req.body.question, answer: req.body.answer });
+    res.status(201).json(faq);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// PUT /api/faqs/:id
+router.put('/:id', async (req, res) => {
+  try {
+    const faq = await Faq.findByIdAndUpdate(
+      req.params.id,
+      { question: req.body.question, answer: req.body.answer },
+      { new: true }
+    );
+    if (!faq) return res.status(404).json({ error: 'Not found' });
+    res.json(faq);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /api/faqs/:id
+router.delete('/:id', async (req, res) => {
+  try {
+    const faq = await Faq.findByIdAndDelete(req.params.id);
+    if (!faq) return res.status(404).json({ error: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/backend/tests/contentFaq.test.js
+++ b/backend/tests/contentFaq.test.js
@@ -1,0 +1,45 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app.js';
+import Content from '../src/models/Content.js';
+import Faq from '../src/models/Faq.js';
+import assert from 'assert';
+
+let mongoServer;
+
+before(async () => {
+  await mongoose.disconnect();
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri, { dbName: 'travonex-test' });
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Content and FAQ routes', () => {
+  it('creates and fetches page content', async () => {
+    const slug = 'test-page';
+    await request(app).put(`/api/content/${slug}`).send({ body: 'Hello' }).expect(200);
+    const res = await request(app).get(`/api/content/${slug}`);
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.slug, slug);
+    assert.equal(res.body.body, 'Hello');
+  });
+
+  it('adds and updates an FAQ', async () => {
+    const createRes = await request(app).post('/api/faqs').send({ question: 'Q?', answer: 'A' });
+    assert.equal(createRes.statusCode, 201);
+    const id = createRes.body._id;
+    const updateRes = await request(app).put(`/api/faqs/${id}`).send({ question: 'Q2', answer: 'A2' });
+    assert.equal(updateRes.statusCode, 200);
+    assert.equal(updateRes.body.answer, 'A2');
+    const listRes = await request(app).get('/api/faqs');
+    assert.equal(listRes.statusCode, 200);
+    assert.equal(listRes.body.length, 1);
+    assert.equal(listRes.body[0]._id, id);
+  });
+});


### PR DESCRIPTION
## Summary
- model `Content` with `slug` and `body` fields
- model `Faq` with question/answer
- add routes for `/api/content` and `/api/faqs`
- register new routes
- test content and faq CRUD paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b0a4660ac8328bd636afec91784a3