### PR TITLE
Add admin roles and users API

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -25,6 +25,7 @@ import loginRouter from './routes/login.js';
 import paymentsRouter from './routes/payments.js';
 import otpSignupRouter from './routes/otpSignup.js';
 import adminRouter from './routes/admin.js';
+import adminAccessRouter from './routes/adminAccess.js';
 
 // Mapping of base paths to routers for Swagger docs
 export const routeMappings = [
@@ -43,6 +44,7 @@ export const routeMappings = [
   ['/api/upload', uploadRouter],
   ['/api/payments', paymentsRouter],
   ['/api/admin', adminRouter],
+  ['/api/admin', adminAccessRouter],
   ['/api/protected', protectedRouter],
   ['/api/auth/signup', signupRouter],
   ['/api/auth/login', loginRouter],

--- a/backend/src/models/AdminUser.js
+++ b/backend/src/models/AdminUser.js
@@ -5,8 +5,8 @@ const adminUserSchema = new mongoose.Schema({
     name: String,
     email: { type: String, unique: true },
     password: String,
-    role: { type: String, default: 'admin' },
-    status: { type: String, enum: ['Active', 'Suspended'], default: 'Active' },
+    role: { type: mongoose.Schema.Types.ObjectId, ref: 'Role' },
+    status: { type: String, enum: ['Active', 'Inactive', 'Suspended'], default: 'Active' },
 });
 
 adminUserSchema.methods.comparePassword = function (candidatePassword) {

--- a/backend/src/models/Role.js
+++ b/backend/src/models/Role.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const roleSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  description: String,
+  permissions: { type: mongoose.Schema.Types.Mixed, default: {} },
+}, { timestamps: true });
+
+export default mongoose.model('Role', roleSchema);

--- a/backend/src/routes/adminAccess.js
+++ b/backend/src/routes/adminAccess.js
@@ -1,0 +1,93 @@
+import express from 'express';
+import bcrypt from 'bcryptjs';
+import Role from '../models/Role.js';
+import AdminUser from '../models/AdminUser.js';
+import { requireJwt } from '../middlewares/jwtAuth.js';
+
+const router = express.Router();
+
+// ----- Roles -----
+router.get('/roles', requireJwt('admin'), async (req, res) => {
+  const roles = await Role.find();
+  res.json(roles);
+});
+
+router.post('/roles', requireJwt('admin'), async (req, res) => {
+  try {
+    const role = new Role(req.body);
+    await role.save();
+    res.status(201).json(role);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+router.get('/roles/:id', requireJwt('admin'), async (req, res) => {
+  const role = await Role.findById(req.params.id);
+  if (!role) return res.status(404).json({ message: 'Role not found' });
+  res.json(role);
+});
+
+router.put('/roles/:id', requireJwt('admin'), async (req, res) => {
+  try {
+    const role = await Role.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true, runValidators: true }
+    );
+    if (!role) return res.status(404).json({ message: 'Role not found' });
+    res.json(role);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+router.delete('/roles/:id', requireJwt('admin'), async (req, res) => {
+  try {
+    const inUse = await AdminUser.findOne({ role: req.params.id });
+    if (inUse) return res.status(400).json({ message: 'Role assigned to users' });
+    const deleted = await Role.findByIdAndDelete(req.params.id);
+    if (!deleted) return res.status(404).json({ message: 'Role not found' });
+    res.json({ message: 'Role deleted' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// ----- Admin Users -----
+router.get('/users', requireJwt('admin'), async (req, res) => {
+  const admins = await AdminUser.find().populate('role');
+  res.json(admins);
+});
+
+router.post('/users', requireJwt('admin'), async (req, res) => {
+  try {
+    const { password, ...rest } = req.body;
+    const hashed = await bcrypt.hash(password, 10);
+    const admin = new AdminUser({ ...rest, password: hashed });
+    await admin.save();
+    res.status(201).json(admin);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+router.put('/users/:id', requireJwt('admin'), async (req, res) => {
+  try {
+    const updates = { ...req.body };
+    if (updates.password) {
+      updates.password = await bcrypt.hash(updates.password, 10);
+    }
+    const admin = await AdminUser.findByIdAndUpdate(
+      req.params.id,
+      updates,
+      { new: true, runValidators: true }
+    ).populate('role');
+    if (!admin) return res.status(404).json({ message: 'Admin not found' });
+    res.json(admin);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/backend/tests/adminAccess.test.js
+++ b/backend/tests/adminAccess.test.js
@@ -1,0 +1,63 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app.js';
+import Role from '../src/models/Role.js';
+import assert from 'assert';
+
+let mongoServer;
+let token;
+
+before(async () => {
+  await mongoose.disconnect();
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri, { dbName: 'travonex-test' });
+  process.env.JWT_SECRET = 'testsecret';
+  token = jwt.sign({ id: 'admin1', role: 'admin' }, process.env.JWT_SECRET);
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Admin roles and users routes', () => {
+  it('creates and lists roles', async () => {
+    const resCreate = await request(app)
+      .post('/api/admin/roles')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Support', permissions: { Dashboard: ['View'] } });
+    assert.equal(resCreate.statusCode, 201);
+
+    const resList = await request(app)
+      .get('/api/admin/roles')
+      .set('Authorization', `Bearer ${token}`);
+    assert.equal(resList.statusCode, 200);
+    assert.equal(resList.body.length, 1);
+  });
+
+  it('creates and updates an admin user', async () => {
+    const role = await Role.findOne();
+    const resCreate = await request(app)
+      .post('/api/admin/users')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Admin',
+        email: 'a@example.com',
+        password: 'secret123',
+        role: role._id,
+        status: 'Active'
+      });
+    assert.equal(resCreate.statusCode, 201);
+    const admin = resCreate.body;
+
+    const resUpdate = await request(app)
+      .put(`/api/admin/users/${admin._id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'Suspended' });
+    assert.equal(resUpdate.statusCode, 200);
+    assert.equal(resUpdate.body.status, 'Suspended');
+  });
+});


### PR DESCRIPTION
## Summary
- implement Role model with permissions
- update AdminUser model to reference a Role
- create adminAccess router exposing /api/admin/roles and /api/admin/users
- mount new router in app.js
- add tests covering new admin role and user routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b0a48dcf88328bc75d75c17753c84