### PR TITLE
Add create booking endpoint

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -192,7 +192,7 @@ Your database schema should align with the TypeScript types defined in `src/lib/
 The frontend is built to call these (or similar) API endpoints. You will find `// BACKEND:` comments in the code pointing to these specific integration points.
 
 *   **Auth:** `POST /api/auth/login`, `POST /api/auth/signup`, `POST /api/auth/logout`
-*   **Users (Public):** `GET /api/trips`, `GET /api/trips/slug/{slug}`, `POST /api/bookings`
+*   **Users (Public):** `GET /api/trips`, `GET /api/trips/slug/{slug}`, `POST /api/bookings/create` (preferred) or `POST /api/bookings`
 *   **Payments:** `POST /api/payments/create-order`, `POST /api/payments/verify`
 *   **Users (Authenticated):** `GET /api/users/me/profile`, `PUT /api/users/me/profile`, `GET /api/users/me/bookings`
 *   **Organizers:** `GET /api/organizers/me/dashboard`, `GET /api/organizers/me/trips`, `POST /api/trips`, `PUT /api/trips/{id}`, `DELETE /api/trips/{id}`, `GET /api/organizers/me/bookings`, `GET /api/organizers/me/payouts`, `POST /api/organizers/me/payouts/request`

--- a/backend/src/routes/bookings.js
+++ b/backend/src/routes/bookings.js
@@ -23,8 +23,8 @@ router.get('/user/:userId', async (req, res) => {
     }
 });
 
-// Create a new booking
-router.post('/', async (req, res) => {
+// Handler for creating a booking
+const createBooking = async (req, res) => {
     try {
         const booking = new Booking(req.body);
         await booking.save();
@@ -32,7 +32,13 @@ router.post('/', async (req, res) => {
     } catch (err) {
         res.status(400).json({ error: err.message });
     }
-});
+};
+
+// Create a new booking
+router.post('/', createBooking);
+
+// Preferred create endpoint
+router.post('/create', createBooking);
 
 // Get a booking by ID
 router.get('/:id', async (req, res) => {

--- a/backend/tests/bookingCreate.test.js
+++ b/backend/tests/bookingCreate.test.js
@@ -1,0 +1,38 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app.js';
+import Booking from '../src/models/Booking.js';
+import Trip from '../src/models/Trip.js';
+import User from '../src/models/User.js';
+import assert from 'assert';
+
+let mongoServer;
+
+before(async () => {
+  await mongoose.disconnect();
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri, { dbName: 'travonex-test' });
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Booking creation via /create', () => {
+  it('creates a booking', async () => {
+    const user = await User.create({ name: 'U', email: `u${Date.now()}@example.com`, password: 'p', referralCode: `ref${Date.now()}` });
+    const trip = await Trip.create({ title: 'T', slug: `t${Date.now()}` });
+    const res = await request(app)
+      .post('/api/bookings/create')
+      .send({ user: user._id.toString(), trip: trip._id.toString() });
+    assert.equal(res.statusCode, 201);
+    assert(res.body._id);
+
+    // ensure booking stored
+    const found = await Booking.findById(res.body._id);
+    assert(found);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `/create` POST route in bookings API
- document preferred `/api/bookings/create` endpoint in README
- test new `/create` booking route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b0a4a1b3483288afc079b03eb2fb1