### PR TITLE
Replace mock data with API fetches

### DIFF
--- a/src/app/api/reviews/trip/[tripId]/route.ts
+++ b/src/app/api/reviews/trip/[tripId]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request, { params }: { params: { tripId: string } }) {
+  try {
+    const backendUrl = `${process.env.BACKEND_URL || 'http://localhost:5000'}/api/reviews/trip/${params.tripId}`;
+    const res = await fetch(backendUrl);
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error(`Failed to fetch reviews for trip ${params.tripId}:`, error);
+    return NextResponse.json({ message: 'An error occurred.' }, { status: 500 });
+  }
+}

--- a/src/app/api/trips/[id]/route.ts
+++ b/src/app/api/trips/[id]/route.ts
@@ -1,5 +1,17 @@
 import { NextResponse } from 'next/server';
 
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const backendUrl = `${process.env.BACKEND_URL || 'http://localhost:5000'}/api/trips/${params.id}`;
+    const res = await fetch(backendUrl);
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error('Failed to fetch trip:', error);
+    return NextResponse.json({ message: 'An error occurred while fetching trip.' }, { status: 500 });
+  }
+}
+
 export async function PUT(request: Request, { params }: { params: { id: string } }) {
   try {
     const body = await request.json();

--- a/src/app/book/[tripId]/page.tsx
+++ b/src/app/book/[tripId]/page.tsx
@@ -20,8 +20,7 @@
  */
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
-import { users } from "@/lib/mock-data";
+import { useState, useEffect, useMemo } from "react";
 import type { Trip } from "@/lib/types";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -83,14 +82,24 @@ export default function BookingPage() {
   const batchId = searchParams.get('batch');
   const { toast } = useToast();
   
-  const { user: sessionUser, loading: authLoading } = useAuth();
-  
-  // DEV_COMMENT: The component now uses the actual logged-in user's data from the AuthContext.
-  // We find the full user profile from the mock data array based on the session ID.
-  const currentUser = useMemo(() => {
-    if (!sessionUser) return null;
-    return users.find(u => u.id === sessionUser.id);
-  }, [sessionUser]);
+  const { user: sessionUser, token, loading: authLoading } = useAuth();
+  const [currentUser, setCurrentUser] = useState<any | null>(null);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      if (!sessionUser) return;
+      try {
+        const res = await fetch('/api/users/me/profile', { headers: { Authorization: token ? `Bearer ${token}` : '' } });
+        if (res.ok) {
+          const data = await res.json();
+          setCurrentUser(data);
+        }
+      } catch (err) {
+        console.error('Profile fetch error:', err);
+      }
+    };
+    loadProfile();
+  }, [sessionUser, token]);
 
 
   // DEV_COMMENT: START - Profile Completion and Auth Gate

--- a/src/app/bookings/page.tsx
+++ b/src/app/bookings/page.tsx
@@ -14,9 +14,8 @@
  */
 import * as React from "react";
 import { BookingsClient } from "@/components/bookings/BookingsClient";
-import { trips, organizers } from "@/lib/mock-data";
 import { cookies } from "next/headers";
-import type { UserSession } from "@/lib/types";
+import type { UserSession, Trip, Organizer } from "@/lib/types";
 
 // DEV_COMMENT: Data fetching now happens on the server before the page is rendered.
 // It securely reads the session cookie to identify the user.
@@ -41,8 +40,32 @@ async function getUserBookings() {
   }
 }
 
+async function getTrips() : Promise<Trip[]> {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/trips`);
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}
+
+async function getOrganizers() : Promise<Organizer[]> {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/organizers`);
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}
+
 export default async function BookingsPage() {
-  const userBookings = await getUserBookings();
+  const [userBookings, trips, organizers] = await Promise.all([
+    getUserBookings(),
+    getTrips(),
+    getOrganizers(),
+  ]);
 
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
@@ -60,10 +83,10 @@ export default async function BookingsPage() {
         This pattern allows for fast initial page loads with server-side rendering,
         while still enabling rich client-side interactivity.
       */}
-      <BookingsClient 
-        initialBookings={userBookings} 
-        allTrips={trips} 
-        allOrganizers={organizers} 
+      <BookingsClient
+        initialBookings={userBookings}
+        allTrips={trips}
+        allOrganizers={organizers}
       />
     </main>
   );

--- a/src/app/trip-organiser/trips/[tripId]/edit/page.tsx
+++ b/src/app/trip-organiser/trips/[tripId]/edit/page.tsx
@@ -1,9 +1,18 @@
 import { TripForm } from "@/components/trips/TripForm";
-import { trips } from "@/lib/mock-data";
 import { notFound } from "next/navigation";
 
-export default function EditTripPage({ params }: { params: { tripId: string } }) {
-    const trip = trips.find(t => t.id === params.tripId);
+async function getTrip(tripId: string) {
+    try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/trips/${tripId}`);
+        if (!res.ok) return null;
+        return await res.json();
+    } catch {
+        return null;
+    }
+}
+
+export default async function EditTripPage({ params }: { params: { tripId: string } }) {
+    const trip = await getTrip(params.tripId);
     if (!trip) {
         notFound();
     }

--- a/src/app/trips/[slug]/page.tsx
+++ b/src/app/trips/[slug]/page.tsx
@@ -38,7 +38,6 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ClientOnlyDate } from "@/components/common/ClientOnlyDate";
 import type { TripBatch, Point, ItineraryItem, FAQ } from "@/lib/types";
-import { users } from "@/lib/mock-data";
 
 
 // DEV_COMMENT: Data fetching now happens on the server.
@@ -48,7 +47,9 @@ async function getTripData(slug: string) {
         return { trip: null, organizer: null };
     }
     const data = await res.json();
-    return { trip: data, organizer: data.organizer };
+    const reviewsRes = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/reviews/trip/${data.id}`);
+    const reviews = reviewsRes.ok ? await reviewsRes.json() : [];
+    return { trip: { ...data, reviews }, organizer: data.organizer };
 }
 
 
@@ -387,8 +388,8 @@ export default async function TripDetailsPage({ params }: { params: { slug: stri
                     )}
 
                     <div className="space-y-4">
-                        {trip.reviews?.map((review: { id: string; userId: string; rating: number; comment: string }) => {
-                            const user = users.find(u => u.id === review.userId);
+                        {trip.reviews?.map((review: { id: string; user: { name: string }; rating: number; comment: string }) => {
+                            const user = review.user;
                             return (
                                 <div key={review.id} className="flex gap-4 border-t pt-4 first:border-t-0 first:pt-0">
                                     <Avatar>


### PR DESCRIPTION
## Summary
- add GET endpoint to trips by ID and new reviews API route
- fetch data from API routes instead of mock arrays
- use organizer reviews, bookings, payouts from server
- retrieve user profile for booking flow
- load trips and organizers on bookings page

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b113ea9348328ab1aac1dc377f2b7