### PR TITLE
Emphasize setup steps before tests

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -216,13 +216,23 @@ The frontend is built to call these (or similar) API endpoints. You will find `/
 
 ## 7. Running Tests
 
-Use the root `test` script to run the backend test suite:
+Before running the tests, install dependencies in **both** the project root and the
+`backend` folder:
+
+```bash
+npm install
+cd backend && npm install
+```
+
+After the dependencies are installed, use the root `test` script to run the backend
+test suite:
 
 ```bash
 npm test
 ```
 
-This command runs `npm --prefix backend test`, executing the tests located in the `backend` directory.
+This command runs `npm --prefix backend test`, executing the tests located in the
+`backend` directory.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a reminder in README2.md to install dependencies in both directories prior to running tests

## Testing
- `npm test` *(fails: Audit log routes tests)*

------
https://chatgpt.com/codex/tasks/task_e_687b114097508328ba672ff177ec8ec0