### PR TITLE
Improve swagger default responses

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -88,7 +88,7 @@ app.get('/', (req, res) => {
     res.send('Travonex Backend API');
 });
 
-const swaggerSpec = generateSwaggerSpec(app, routeMappings);
+const swaggerSpec = generateSwaggerSpec(app);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // 404 handler

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -1,20 +1,50 @@
 import swaggerJsdoc from 'swagger-jsdoc';
 import listEndpoints from 'express-list-endpoints';
 
-function extractRoutes(router, base = '') {
-  const routes = [];
-  for (const layer of router.stack || []) {
-    if (layer.route) {
-      const routePath =
-        layer.route.path === '/' ? base : `${base}${layer.route.path}`;
-      const methods = Object.keys(layer.route.methods).map((m) => m.toUpperCase());
-      routes.push({ path: routePath, methods });
-    }
+// Common status code responses for documentation
+const DEFAULT_RESPONSES = {
+  GET: {
+    200: { description: 'OK' },
+    400: { description: 'Bad Request' },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not Found' },
+    500: { description: 'Server Error' }
+  },
+  POST: {
+    201: { description: 'Created' },
+    400: { description: 'Bad Request' },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not Found' },
+    500: { description: 'Server Error' }
+  },
+  PUT: {
+    200: { description: 'OK' },
+    400: { description: 'Bad Request' },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not Found' },
+    500: { description: 'Server Error' }
+  },
+  PATCH: {
+    200: { description: 'OK' },
+    400: { description: 'Bad Request' },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not Found' },
+    500: { description: 'Server Error' }
+  },
+  DELETE: {
+    200: { description: 'OK' },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not Found' },
+    500: { description: 'Server Error' }
   }
-  return routes;
-}
+};
 
-export default function generateSwaggerSpec(app, mappings = []) {
+export default function generateSwaggerSpec(app) {
   const options = {
     definition: {
       openapi: '3.0.0',
@@ -29,54 +59,28 @@ export default function generateSwaggerSpec(app, mappings = []) {
 
   const spec = swaggerJsdoc(options);
   spec.paths = spec.paths || {};
-  const configs = mappings.length ? mappings : app ? [['', app]] : [];
 
-  configs.forEach(([base, router]) => {
-    for (const { path, methods } of extractRoutes(router, base)) {
-      if (!path.startsWith('/api')) continue;
-      const openapiPath = path.replace(/:([^/]+)/g, '{$1}');
-      spec.paths[openapiPath] = spec.paths[openapiPath] || {};
-      for (const method of methods) {
-        const lower = method.toLowerCase();
-        if (!spec.paths[openapiPath][lower]) {
-          spec.paths[openapiPath][lower] = {
-            summary: `${method} ${path}`,
-            responses: {
-              200: { description: 'Success' }
-            }
-          };
-        }
+  const endpoints = listEndpoints(app);
+  endpoints.forEach(({ path, methods }) => {
+    if (!path.startsWith('/api')) return;
+    const openapiPath = path.replace(/:([^/]+)/g, '{$1}');
+    spec.paths[openapiPath] = spec.paths[openapiPath] || {};
+
+    methods.forEach((method) => {
+      const lower = method.toLowerCase();
+      if (!spec.paths[openapiPath][lower]) {
+        spec.paths[openapiPath][lower] = {
+          summary: `${method} ${path}`,
+          responses: { ...DEFAULT_RESPONSES[method] }
+        };
+      } else {
+        spec.paths[openapiPath][lower].responses = {
+          ...DEFAULT_RESPONSES[method],
+          ...(spec.paths[openapiPath][lower].responses || {})
+        };
       }
-    }
-  });
-  if (app) {
-    spec.paths = spec.paths || {};
-    const configs = mappings.length
-      ? mappings
-      : [['', app]];
-    configs.forEach(([base, router]) => {
-      const endpoints = listEndpoints(router);
-      endpoints.forEach(({ path, methods }) => {
-        const fullPath = `${base}${path}`;
-        if (!fullPath.startsWith('/api')) return;
-        const openapiPath = fullPath.replace(/:([^/]+)/g, '{$1}');
-        if (!spec.paths[openapiPath]) {
-          spec.paths[openapiPath] = {};
-        }
-        methods.forEach(method => {
-          const lower = method.toLowerCase();
-          if (!spec.paths[openapiPath][lower]) {
-            spec.paths[openapiPath][lower] = {
-              summary: `${method} ${fullPath}`,
-              responses: {
-                200: { description: 'Success' }
-              }
-            };
-          }
-        });
-      });
     });
-  }
+  });
 
   // Merge duplicate paths that may include trailing slashes
   const deduped = {};


### PR DESCRIPTION
## Summary
- add common HTTP response definitions
- merge defaults with auto-generated paths in Swagger

## Testing
- `npm test` *(fails: Audit log routes)*

------
https://chatgpt.com/codex/tasks/task_e_687b19412d9c83289a2cda3310eb69e9