### PR TITLE
Fix Swagger route extraction

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -88,7 +88,7 @@ app.get('/', (req, res) => {
     res.send('Travonex Backend API');
 });
 
-const swaggerSpec = generateSwaggerSpec(app);
+const swaggerSpec = generateSwaggerSpec(app, routeMappings);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // 404 handler


### PR DESCRIPTION
## Summary
- implement `extractRoutes` helper for analyzing Express routers
- generate Swagger spec using mapped routers
- pass routeMappings to Swagger setup

## Testing
- `npm test` *(fails: AssertionError 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_687b32086fa48328a7cf1c1867f4d94b