### PR TITLE
Fix swagger docs generation and failing tests

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -89,7 +89,6 @@ app.get('/', (req, res) => {
 });
 
 const swaggerSpec = generateSwaggerSpec(routeMappings);
-const swaggerSpec = generateSwaggerSpec(app, routeMappings);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // 404 handler

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -23,7 +23,6 @@ export function extractEndpoints(routeMappings) {
   return routes;
 }
 
-
 // Common status code responses for documentation
 const DEFAULT_RESPONSES = {
   GET: {
@@ -68,22 +67,6 @@ const DEFAULT_RESPONSES = {
 };
 
 export default function generateSwaggerSpec(routeMappings) {
-export function extractRoutes(router, base = '') {
-  const routes = [];
-  for (const layer of router.stack || []) {
-    if (layer.route) {
-      const path = base + (layer.route.path === '/' ? '' : layer.route.path);
-      const methods = Object.keys(layer.route.methods).map((m) => m.toUpperCase());
-      routes.push({ path, methods });
-    } else if (layer.name === 'router' && layer.handle && layer.handle.stack) {
-      const nestedBase = base + (layer.path || '');
-      routes.push(...extractRoutes(layer.handle, nestedBase));
-    }
-  }
-  return routes;
-}
-
-export default function generateSwaggerSpec(app, routeMappings = []) {
   const options = {
     definition: {
       openapi: '3.0.0',
@@ -120,29 +103,6 @@ export default function generateSwaggerSpec(app, routeMappings = []) {
       }
     });
   });
-  for (const [basePath, router] of routeMappings) {
-    const routes = extractRoutes(router, basePath);
-    for (const { path, methods } of routes) {
-      if (!path.startsWith('/api')) continue;
-      const openapiPath = path.replace(/:([^/]+)/g, '{$1}');
-      spec.paths[openapiPath] = spec.paths[openapiPath] || {};
-      methods.forEach((method) => {
-        const upper = method.toUpperCase();
-        const lower = method.toLowerCase();
-        if (!spec.paths[openapiPath][lower]) {
-          spec.paths[openapiPath][lower] = {
-            summary: `${upper} ${path}`,
-            responses: { ...DEFAULT_RESPONSES[upper] }
-          };
-        } else {
-          spec.paths[openapiPath][lower].responses = {
-            ...DEFAULT_RESPONSES[upper],
-            ...(spec.paths[openapiPath][lower].responses || {})
-          };
-        }
-      });
-    }
-  }
 
   // Merge duplicate paths that may include trailing slashes
   const deduped = {};

--- a/backend/tests/auditLogs.test.js
+++ b/backend/tests/auditLogs.test.js
@@ -25,7 +25,11 @@ after(async () => {
 
 describe('Audit log routes', () => {
   it('records a log on trip update and retrieves logs', async () => {
-    const admin = await AdminUser.create({ name: 'A', email: 'a@example.com', password: 'pass' });
+    const admin = await AdminUser.create({
+      name: 'A',
+      email: `admin-${Date.now()}@example.com`,
+      password: 'pass'
+    });
     token = jwt.sign({ id: admin._id.toString(), role: 'admin' }, process.env.JWT_SECRET);
     const trip = await Trip.create({ title: 'T', slug: 'audit-trip' });
 


### PR DESCRIPTION
## Summary
- repair swagger generation logic and keep one export
- remove duplicate swagger invocation in `app.js`
- ensure unique admin email in audit log tests

## Testing
- `npm --prefix backend ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b4b7dd904832887510c6cfe180f07