### PR TITLE
Fix signup route duplication

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -180,7 +180,7 @@ Your database schema should align with the TypeScript types defined in `src/lib/
 *   **Logic:** This endpoint should check the user's credentials against the `AdminUser`, `Organizer`, and `User` tables to determine their role.
 *   **Response:** On successful login, the API should return a session token (e.g., JWT) and a user object containing `id`, `name`, `email`, `role`, and `avatar`.
 *   **Session Management:** The frontend uses `localStorage` to persist the session. All subsequent API calls should include the token in the `Authorization` header for validation.
-*   **Signup:** Users and organizers register using phone number verification. The frontend obtains a Firebase ID token after OTP verification and sends it to `POST /api/auth/signup` along with the user's name, email, and desired role.
+*   **Signup:** Users and organizers register using phone number verification. The frontend obtains a Firebase ID token after OTP verification and sends it to `POST /api/auth/signup` along with the user's name, email, and desired role. The signup page is available at `/auth/signup` (the former `/auth/otp-signup` route now simply redirects here).
 *   **Login:** Phone-based logins also use Firebase verification. After confirming the OTP, the frontend sends the resulting ID token as the `credential` in `POST /api/auth/login`.
     On success, the API responds with a `redirectPath` indicating the role-specific
     dashboard (`/trip-organiser/dashboard` for organizers, `/` for regular users, or

--- a/src/app/api/auth/otp-signup/route.ts
+++ b/src/app/api/auth/otp-signup/route.ts
@@ -1,17 +1,1 @@
-import { NextResponse } from 'next/server';
-
-export async function POST(request: Request) {
-  try {
-    const body = await request.json();
-    const backendRes = await fetch(`${process.env.BACKEND_URL || 'http://localhost:5000'}/api/auth/otp-signup`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    const data = await backendRes.json();
-    return NextResponse.json(data, { status: backendRes.status });
-  } catch (err) {
-    console.error('OTP signup error:', err);
-    return NextResponse.json({ message: 'An internal server error occurred' }, { status: 500 });
-  }
-}
+export { POST } from '../signup/route';

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -25,7 +25,7 @@ import { NextResponse } from 'next/server';
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const backendRes = await fetch(`${process.env.BACKEND_URL || 'http://localhost:5000'}/api/auth/otp-signup`, {
+    const backendRes = await fetch(`${process.env.BACKEND_URL || 'http://localhost:5000'}/api/auth/signup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/src/app/auth/otp-signup/page.tsx
+++ b/src/app/auth/otp-signup/page.tsx
@@ -1,88 +1,11 @@
-"use client";
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
-import { useState } from "react";
-import { RecaptchaVerifier, signInWithPhoneNumber, ConfirmationResult } from "firebase/auth";
-import { auth } from "@/firebase/client";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardFooter,
-} from "@/components/ui/card";
-import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
-import { useToast } from "@/hooks/use-toast";
-
-export default function OtpSignupPage() {
-  const { toast } = useToast();
-  const [phone, setPhone] = useState("");
-  const [otp, setOtp] = useState("");
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [role, setRole] = useState("USER");
-  const [confirmation, setConfirmation] = useState<ConfirmationResult | null>(null);
-
-  const sendOtp = async () => {
-    try {
-      const verifier = new RecaptchaVerifier(auth, "recaptcha-container", { size: "invisible" });
-      const result = await signInWithPhoneNumber(auth, phone, verifier);
-      setConfirmation(result);
-      toast({ title: "OTP sent" });
-    } catch (err: any) {
-      toast({ variant: "destructive", title: "Failed to send OTP", description: err.message });
-    }
-  };
-
-  const verifyOtp = async () => {
-    if (!confirmation) return;
-    try {
-      const cred = await confirmation.confirm(otp);
-      const idToken = await cred.user.getIdToken();
-      const res = await fetch("/api/auth/otp-signup", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ idToken, name, email, role }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.message || "Signup failed");
-      toast({ title: "Signup successful" });
-    } catch (err: any) {
-      toast({ variant: "destructive", title: "Verification failed", description: err.message });
-    }
-  };
-
-  return (
-    <Card className="w-full max-w-sm">
-      <CardHeader>
-        <CardTitle>Phone Signup</CardTitle>
-      </CardHeader>
-      <CardContent className="grid gap-4">
-        <Input placeholder="Full Name" value={name} onChange={(e) => setName(e.target.value)} />
-        <Input placeholder="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
-        <Input placeholder="Phone Number" value={phone} onChange={(e) => setPhone(e.target.value)} />
-        <Select defaultValue={role} onValueChange={(val) => setRole(val)}>
-          <SelectTrigger>
-            <SelectValue placeholder="Select role" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="USER">User</SelectItem>
-            <SelectItem value="ORGANIZER">Trip Organizer</SelectItem>
-          </SelectContent>
-        </Select>
-        {confirmation && (
-          <Input placeholder="OTP" value={otp} onChange={(e) => setOtp(e.target.value)} />
-        )}
-        <div id="recaptcha-container"></div>
-      </CardContent>
-      <CardFooter>
-        {confirmation ? (
-          <Button className="w-full" onClick={verifyOtp}>Verify &amp; Sign Up</Button>
-        ) : (
-          <Button className="w-full" onClick={sendOtp}>Send OTP</Button>
-        )}
-      </CardFooter>
-    </Card>
-  );
+export default function RedirectSignup() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/auth/signup');
+  }, [router]);
+  return null;
 }

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,8 +1,12 @@
-export const saveUserRole = async (idToken: string, role: string, info: Record<string, any>) => {
+export const saveUserRole = async (
+  idToken: string,
+  role: string,
+  info: Record<string, any>
+) => {
   const res = await fetch('/api/auth/signup', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ idToken, role, ...info })
+    body: JSON.stringify({ idToken, accountType: role, terms: true, ...info })
   });
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- redirect `/auth/otp-signup` to `/auth/signup`
- send account type and terms in `saveUserRole`
- point signup API route to backend `/api/auth/signup`
- reuse same handler for `/api/auth/otp-signup`
- document the redirect in README2

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba749a8488328b5092a5a8b9475e2